### PR TITLE
Add initial framework for stctl command

### DIFF
--- a/cmd/stctl/main.go
+++ b/cmd/stctl/main.go
@@ -1,0 +1,120 @@
+// Copyright © 2019 gcp-config Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/m-lab/gcp-config/internal/stctl"
+	"github.com/m-lab/gcp-config/transfer"
+
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
+	"google.golang.org/api/storagetransfer/v1"
+)
+
+var (
+	project      string
+	sourceBucket string
+	destBucket   string
+	prefixes     flagx.StringArray
+	startTime    flagx.Time
+	afterDate    flagx.DateTime
+)
+
+func init() {
+	flag.StringVar(&project, "project", "", "GCP project to sync transfer job.")
+	flag.StringVar(&sourceBucket, "gcs.source", "", "Source GCS bucket.")
+	flag.StringVar(&destBucket, "gcs.target", "", "Destination bucket.")
+	flag.Var(&prefixes, "include", "Only transfer files with given prefix. Default all prefixes. Can be specified multiple times.")
+	flag.Var(&startTime, "time", "Start daily transfer at this time (HH:MM:SS)")
+	flag.Var(&afterDate, "after", "Only list operations that ran after the given date. Default is all dates.")
+}
+
+var usageText = `
+NAME
+  stctl - storage transfer control
+
+DESCRIPTION
+  stctl allows a user to create, disable, and list storage transfer jobs and
+  list past transfer operations for existing jobs.
+
+EXAMPLES
+  stctl -project <project> list
+
+  stctl -project <project> operations <job name>
+
+  stctl -project <project> create -gcs.source <bucket> -gcs.target <bucket> \
+    -time <HH:MM:SS> -include ndt -include host -include neubot -include utilization
+
+  stctl -project <project> disable <job name>
+
+USAGE
+`
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), usageText)
+		flag.PrintDefaults()
+	}
+}
+
+func mustArg(n int) string {
+	args := flag.Args()
+	if len(args)-1 < n {
+		flag.Usage()
+		os.Exit(1)
+	}
+	return args[n]
+}
+
+func main() {
+	flag.Parse()
+	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Failed to parse flags")
+
+	ctx := context.Background()
+	service, err := storagetransfer.NewService(ctx)
+	rtx.Must(err, "Failed to create new storage transfer service")
+
+	cmd := &stctl.Command{
+		Job:          transfer.NewJob(project, service),
+		Project:      project,
+		SourceBucket: sourceBucket,
+		TargetBucket: destBucket,
+		Prefixes:     prefixes,
+		StartTime:    startTime,
+		AfterDate:    afterDate.Time,
+	}
+
+	op := mustArg(0)
+	switch op {
+	case "create":
+		rtx.Must(cmd.Create(ctx), "Failed to create")
+	case "sync":
+		rtx.Must(cmd.Sync(ctx), "Failed to sync")
+	case "disable":
+		name := mustArg(1)
+		rtx.Must(cmd.Disable(ctx, name), "Failed to disable %q", name)
+	case "list":
+		rtx.Must(cmd.ListJobs(ctx), "Failed to list jobs")
+	case "operations":
+		name := mustArg(1)
+		rtx.Must(cmd.ListOperations(ctx, name), "Failed to list operations for %q", name)
+	default:
+		flag.Usage()
+	}
+}

--- a/internal/stctl/command.go
+++ b/internal/stctl/command.go
@@ -1,0 +1,101 @@
+// Copyright © 2019 gcp-config Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stctl implements command actions.
+package stctl
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/storagetransfer/v1"
+)
+
+// TransferJob captures the interface required by Command implementations.
+type TransferJob interface {
+	List(ctx context.Context, visit func(resp *storagetransfer.ListTransferJobsResponse) error) error
+	Create(ctx context.Context, create *storagetransfer.TransferJob) (*storagetransfer.TransferJob, error)
+	Get(ctx context.Context, name string) (*storagetransfer.TransferJob, error)
+	Update(ctx context.Context, name string, update *storagetransfer.UpdateTransferJobRequest) (*storagetransfer.TransferJob, error)
+	Operations(ctx context.Context, name string, visit func(r *storagetransfer.ListOperationsResponse) error) error
+}
+
+// Command executes stctl actions.
+type Command struct {
+	Job          TransferJob
+	Project      string
+	SourceBucket string
+	TargetBucket string
+	Prefixes     []string
+	StartTime    flagx.Time
+	AfterDate    time.Time
+}
+
+// ListJobs lists enabled transfer jobs.
+func (c *Command) ListJobs(ctx context.Context) error {
+	return nil
+}
+
+// ListOperations lists past operations for the named job that started after c.AfterDate.
+func (c *Command) ListOperations(ctx context.Context, name string) error {
+	return nil
+}
+
+// Create creates a new storage transfer job.
+func (c *Command) Create(ctx context.Context) error {
+	return nil
+}
+
+// Disable marks the job status as 'DISABLED'.
+func (c *Command) Disable(ctx context.Context, name string) error {
+	return nil
+}
+
+// Sync guarantees that a job exists matching the current command parameters.
+// If a job with matching command parameters already exists, no action is taken.
+// If a matching description is found with different values for IncludePrefixes
+// or StartTimeOfDay, then the original job is disabled and a new job created.
+func (c *Command) Sync(ctx context.Context) error {
+	return nil
+}
+
+// The Metadata field of storagetransfer.TransferOperation must be parsed from a
+// JSON blob. The structs below are a subset of fields available.
+func parseJobMetadata(m googleapi.RawMessage) *jobMetadata {
+	b, err := m.MarshalJSON()
+	rtx.Must(err, "failed to marshal json of raw message")
+	j := &jobMetadata{}
+	rtx.Must(json.Unmarshal(b, j), "Failed to unmarshal jobmessage")
+	return j
+}
+
+type counters struct {
+	ObjectsFound                   string `json:"objectsFoundFromSource"`
+	ObjectsCopied                  string `json:"objectsCopiedToSink"`
+	ObjectsFromSourceSkippedBySync string `json:"objectsFromSourceSkippedBySync"`
+	ObjectsFromSourceFailed        string `json:"objectsFromSourceFailed"`
+}
+
+type jobMetadata struct {
+	TransferSpec *storagetransfer.TransferSpec `json:"transferSpec"`
+	Start        time.Time                     `json:"startTime"`
+	End          time.Time                     `json:"endTime"`
+	Counters     counters                      `json:"counters"`
+	Status       string                        `json:"status"`
+}

--- a/transfer/job.go
+++ b/transfer/job.go
@@ -1,0 +1,82 @@
+// Copyright © 2019 gcp-config Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package transfer wraps the storagetransfer package in a simplified interface.
+// All code MUST be correct by inspection.
+package transfer
+
+import (
+	"context"
+	"encoding/json"
+
+	"google.golang.org/api/storagetransfer/v1"
+)
+
+// Job wraps the storagetransfer API into a simple interface.
+type Job struct {
+	service *storagetransfer.Service
+	project string
+}
+
+// NewJob creates a new Job.
+func NewJob(project string, service *storagetransfer.Service) *Job {
+	return &Job{
+		project: project,
+		service: service,
+	}
+}
+
+// NOTE: the storagetransfer api requires a json object as the filter string. (o_O)
+// This `filter` object automates the formatting of that filter string.
+type filter struct {
+	Project  string   `json:"project_id"`
+	Statuses []string `json:"job_statuses,omitempty"`
+	Names    []string `json:"job_names,omitempty"`
+}
+
+// List calls `visit` on all ENABLED transfer jobs in the current project.
+func (j *Job) List(ctx context.Context, visit func(resp *storagetransfer.ListTransferJobsResponse) error) error {
+	f := filter{
+		Project:  j.project,
+		Statuses: []string{"ENABLED"},
+	}
+	bfilter, _ := json.Marshal(&f)
+	list := j.service.TransferJobs.List().PageSize(20).Filter(string(bfilter))
+	return list.Pages(ctx, visit)
+}
+
+// Create will create a new transfer job.
+func (j *Job) Create(ctx context.Context, create *storagetransfer.TransferJob) (*storagetransfer.TransferJob, error) {
+	return j.service.TransferJobs.Create(create).Context(ctx).Do()
+}
+
+// Get retrieves the named transfer job.
+func (j *Job) Get(ctx context.Context, name string) (*storagetransfer.TransferJob, error) {
+	return j.service.TransferJobs.Get(name).ProjectId(j.project).Context(ctx).Do()
+}
+
+// Update updates the named transfer job with the given configuration.
+func (j *Job) Update(ctx context.Context, name string, update *storagetransfer.UpdateTransferJobRequest) (*storagetransfer.TransferJob, error) {
+	return j.service.TransferJobs.Patch(name, update).Context(ctx).Do()
+}
+
+// Operations lists all operations from the named job.
+func (j *Job) Operations(ctx context.Context, name string, visit func(r *storagetransfer.ListOperationsResponse) error) error {
+	f := filter{
+		Project: j.project,
+		Names:   []string{name},
+	}
+	bfilter, _ := json.Marshal(&f)
+	return j.service.TransferOperations.List("transferOperations").Filter(string(bfilter)).Pages(ctx, visit)
+}


### PR DESCRIPTION
This change adds a support package for wrapping the storagetransfer API in a simpler operation-oriented interface that the `stctl.Command` package will use. As well, this change includes main and the set of commands planned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/1)
<!-- Reviewable:end -->
