### PR TITLE
Add support for integration with CloudBuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.13
+
+ADD . /go/src/github.com/m-lab/gcp-config
+RUN go get -v github.com/m-lab/gcp-config/cmd/stctl

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -1,0 +1,50 @@
+options:
+  env:
+    # The -project flag should be read automatically from the environmnt.
+    - 'PROJECT=$PROJECT_ID'
+
+steps:
+# Create the gcp-config image for later steps.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '-t', 'gcp-config', '.'
+  ]
+
+# 02:00:00 Nodes upload to the pusher-* bucket. 2hrs is the maximum upload delay.
+# 02:10:00 Configure daily pusher to local archive transfer.
+- name: gcp-config
+  args: [
+    'stctl', '-gcs.source=pusher-$PROJECT_ID',
+             '-gcs.target=archive-$PROJECT_ID',
+             '-time=02:10:00',
+             '-include=ndt',
+             '-include=host',
+             '-include=neubot',
+             '-include=utilization',
+             'sync'
+  ]
+  env:
+  - ALLOWED_PROJECTS=mlab-sandbox,mlab-staging,mlab-oti
+
+# 03:10:00 Configure daily local archive to public archive transfer.
+- name: gcp-config
+  args: [
+    'stctl', '-gcs.source=archive-mlab-oti',
+             '-gcs.target=archive-measurement-lab',
+             '-time=03:10:00',
+             'sync'
+  ]
+  env:
+  - ALLOWED_PROJECTS=measurement-lab
+
+# 04:10:00 Gardener or other jobs that depend on the public archive being up to date may run.
+# 04:10:00 Configure daily public archive to backup transfer.
+
+# NOTE: mlab-backups intentionally restricts access. This configuration is documentation.
+#- name: gcp-config
+#  args: [
+#    'stctl', '-gcs.source=archive-measurement-lab',
+#             '-gcs.target=mlab-cold-storage-backup',
+#             '-time=04:10:00',
+#             'sync'
+#  ]


### PR DESCRIPTION
This change adds a basic Dockerfile and Cloud Build configuration for applying the stctl configuration to our common projects.

To support using a single cloud build file across multiple projects, this change also includes a new flag to stctl that makes execution conditional on the specified -allowed-projects -- if the command runs in another project, then it will exit cleanly without applying the config.

After merging this change, we will need to setup the Cloud Build triggers in each project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/6)
<!-- Reviewable:end -->
