### PR TITLE
Add script with steps to normalize GCS archives

### DIFF
--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -14,6 +14,9 @@
 # * remove data from old locations (slower)
 
 
+set -e
+set -x
+
 archive=${1:?Please provide GCS bucket name, e.g. archive-mlab-sandbox}
 
 # NOTE: This will take a very long time, first "rsync" == "cp".

--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# normalize_gcs_archive.sh is a single-use script that will sync legacy
+# datatypes from the <exp>/YYYY pattern to <exp>/<datatype>/YYYY pattern.
+#
+# New data is not being added to the legacy locations. So, running rsync once
+# should be sufficient. However, the steps below run it twice to guarantee that
+# all data is in place.
+#
+# Steps:
+# * rsync data from old to new locations (slow)
+# * delete exits below.
+# * rsync again to confirm all data is copied (faster)
+# * remove data from old locations (slower)
+
+
+archive=${1:?Please provide GCS bucket name, e.g. archive-mlab-sandbox}
+
+# NOTE: This will take a very long time, first "rsync" == "cp".
+# NOTE: The old directories should be removed after the rsync completes.
+
+# NDT web100
+for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
+  gsutil -m rsync -r gs://${archive}/ndt/${year}/ gs://${archive}/ndt/web100/${year}/
+done
+
+# Sidestream web100
+for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
+  gsutil -m rsync -r gs://${archive}/sidestream/${year}/ gs://${archive}/vserver/sidestream/${year}/
+done
+
+# Paris-traceroute
+for year in 2013 2014 2015 2016 2017 2018 2019 ; do
+  gsutil -m rsync -r gs://${archive}/paris-traceroute/${year}/ gs://${archive}/vserver/traceroute/${year}/
+done
+
+# Switch
+for year in 2016 2017 2018 2019 ; do
+  gsutil -m rsync -r gs://${archive}/switch/${year}/ gs://${archive}/utilization/switch/${year}/
+done
+
+# TODO: wait until ndt-server creates the single ndt7 directory name.
+# i.e. https://github.com/m-lab/ndt-server/pull/264 is in production.
+for year in 2019 2020 ; do
+  # NDT7 Upload / Download
+  gsutil -m rsync -r gs://${archive}/ndt/ndt7/upload/${year}/ gs://${archive}/ndt/ndt7/${year}/
+  gsutil -m rsync -r gs://${archive}/ndt/ndt7/download/${year}/ gs://${archive}/ndt/ndt7/${year}/
+done
+
+# Delete exits to proceed to remove legacy folders.
+exit 0
+exit 0
+exit 0
+exit 0
+
+
+################################################################################
+# REMOVE
+################################################################################
+
+# NDT web100
+for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
+  gsutil -m rm -r gs://${archive}/ndt/${year}/
+done
+
+# Sidestream web100
+for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
+  gsutil -m rm -r gs://${archive}/sidestream/${year}/
+done
+
+# Paris-traceroute
+for year in 2013 2014 2015 2016 2017 2018 2019 ; do
+  gsutil -m rm -r gs://${archive}/paris-traceroute/${year}/
+done
+
+# Switch
+for year in 2016 2017 2018 2019 ; do
+  gsutil -m rm -r gs://${archive}/switch/${year}/
+done
+
+# TODO: wait until ndt-server creates the single ndt7 directory name.
+# i.e. https://github.com/m-lab/ndt-server/pull/264 is in production.
+for year in 2019 2020 ; do
+  # NDT7 Upload / Download
+  gsutil -m rm -r gs://${archive}/ndt/ndt7/upload/${year}/
+  gsutil -m rm -r gs://${archive}/ndt/ndt7/download/${year}/
+done

--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -67,12 +67,12 @@ done
 
 # Sidestream web100
 for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
-  safe_rsync gs://${archive}/sidestream/${year}/ gs://${archive}/vserver/sidestream/${year}/
+  safe_rsync gs://${archive}/sidestream/${year}/ gs://${archive}/host/sidestream/${year}/
 done
 
 # Paris-traceroute
 for year in 2013 2014 2015 2016 2017 2018 2019 ; do
-  safe_rsync gs://${archive}/paris-traceroute/${year}/ gs://${archive}/vserver/traceroute/${year}/
+  safe_rsync gs://${archive}/paris-traceroute/${year}/ gs://${archive}/host/traceroute/${year}/
 done
 
 # Switch

--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -45,11 +45,11 @@ function safe_rsync() {
   local dst=$2
 
   # List all files in the src, to compare to all files in dst at the end.
-  gsutil ls $src > src.raw
+  time gsutil ls $src > src.raw
   # Perform copy.
-  gsutil -m rsync -r $src $dst
+  time gsutil -m rsync -r $src $dst
   # List all files in the dst (which should include src files now).
-  gsutil ls $dst > dst.raw
+  time gsutil ls $dst > dst.raw
   # Assert that the src files are found in the dst files.
   assert_src_files_found_in_dst src.raw dst.raw
 }
@@ -101,28 +101,28 @@ exit 0
 
 # NDT web100
 for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
-  gsutil -m rm -r gs://${archive}/ndt/${year}/
+  time gsutil -m rm -r gs://${archive}/ndt/${year}/
 done
 
 # Sidestream web100
 for year in 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 ; do
-  gsutil -m rm -r gs://${archive}/sidestream/${year}/
+  time gsutil -m rm -r gs://${archive}/sidestream/${year}/
 done
 
 # Paris-traceroute
 for year in 2013 2014 2015 2016 2017 2018 2019 ; do
-  gsutil -m rm -r gs://${archive}/paris-traceroute/${year}/
+  time gsutil -m rm -r gs://${archive}/paris-traceroute/${year}/
 done
 
 # Switch
 for year in 2016 2017 2018 2019 ; do
-  gsutil -m rm -r gs://${archive}/switch/${year}/
+  time gsutil -m rm -r gs://${archive}/switch/${year}/
 done
 
 # TODO: wait until ndt-server creates the single ndt7 directory name.
 # i.e. https://github.com/m-lab/ndt-server/pull/264 is in production.
 for year in 2019 2020 ; do
   # NDT7 Upload / Download
-  gsutil -m rm -r gs://${archive}/ndt/ndt7/upload/${year}/
-  gsutil -m rm -r gs://${archive}/ndt/ndt7/download/${year}/
+  time gsutil -m rm -r gs://${archive}/ndt/ndt7/upload/${year}/
+  time gsutil -m rm -r gs://${archive}/ndt/ndt7/download/${year}/
 done


### PR DESCRIPTION
This change adds an adhoc script that will be run twice.

1. to perform an rsync between all legacy, parsed datatypes to their canonical `<exp>/<datatype>/YYYY/...` names.
2. to do the same operation again, followed by removing the legacy names.

These steps can optionally be automated using cloud build; let me know if you'd prefer that.

FYI: @pboothe @yachang @critzo

Part of https://github.com/m-lab/dev-tracker/issues/548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/16)
<!-- Reviewable:end -->
