### PR TITLE
Add custom golang and gcloud builders enabled with cbif

### DIFF
--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,0 +1,5 @@
+FROM golang:1.13
+ADD . /go/src/github.com/m-lab/gcp-config
+RUN apt-get update && apt-get install -y git
+RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -1,0 +1,42 @@
+# Build cbif for entrypoint.
+FROM golang:1.13 AS cbif-go-builder
+ADD . /go/src/github.com/m-lab/gcp-config
+#WORKDIR /go/src/github.com/m-lab/gcp-config/
+RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+
+# Build Go version of jsonnet.
+FROM golang:1.13 AS jsonnet-go-builder
+RUN apt-get install -y git
+RUN go get -v github.com/google/go-jsonnet/cmd/jsonnet
+
+# Build CPP version of jsonnet.
+# NOTE: Use the same base image as the final image so that shared libraries
+# match the jsonnet binary.
+FROM gcr.io/cloud-builders/gcloud AS jsonnet-cpp-builder
+RUN apt-get update
+RUN apt-get install -y build-essential git wget
+WORKDIR /opt
+RUN wget https://github.com/google/jsonnet/archive/v0.15.0.tar.gz
+RUN tar -C /opt/ -xf v0.15.0.tar.gz
+RUN mv jsonnet-0.15.0 jsonnet
+RUN cd jsonnet && make
+
+############################################################################
+# FINAL IMAGE: based on upstream gcloud builder.
+FROM gcr.io/cloud-builders/gcloud
+
+# Install binaries from builds above.
+COPY --from=cbif-go-builder  /go/bin/cbif /usr/bin/cbif
+COPY --from=jsonnet-go-builder  /go/bin/jsonnet /usr/bin/jsonnet-go
+COPY --from=jsonnet-cpp-builder /opt/jsonnet/jsonnet /usr/bin
+COPY --from=jsonnet-cpp-builder /opt/jsonnet/jsonnetfmt /usr/bin
+RUN curl -o /usr/bin/sjsonnet.jar https://github.com/lihaoyi/sjsonnet/releases/download/0.2.3/sjsonnet.jar
+RUN chmod 755 /usr/bin/sjsonnet.jar
+
+# Install additional dependencies.
+RUN apt-get update
+RUN apt-get install -y dnsutils ca-certificates default-jre-headless make
+RUN update-ca-certificates
+
+WORKDIR /
+ENTRYPOINT ["/usr/bin/cbif"]

--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -1,7 +1,6 @@
 # Build cbif for entrypoint.
 FROM golang:1.13 AS cbif-go-builder
 ADD . /go/src/github.com/m-lab/gcp-config
-#WORKDIR /go/src/github.com/m-lab/gcp-config/
 RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
 
 # Build Go version of jsonnet.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,13 +3,14 @@
 ############################################################################
 
 steps:
-# Build cbif, stand alone container. Useful for import by other repos.
+# Build golang-cbif container. Useful golang builds and tests.
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '--tag=gcr.io/$PROJECT_ID/cbif', '.'
+    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif',
+    '--file=Dockerfile.golang', '.'
   ]
 
-# Build image combining: gcloud, jsonnet, and cbif.
+# Build gcloud-jsonnet-cbif image combining: gcloud, jsonnet, and cbif.
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
@@ -18,5 +19,5 @@ steps:
   ]
 
 images:
-- 'gcr.io/$PROJECT_ID/cbif'
+- 'gcr.io/$PROJECT_ID/golang-cbif'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,22 @@
+############################################################################
+# Create project-specific customized builder images.
+############################################################################
+
+steps:
+# Build cbif, stand alone container. Useful for import by other repos.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '--tag=gcr.io/$PROJECT_ID/cbif', '.'
+  ]
+
+# Build image combining: gcloud, jsonnet, and cbif.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build',
+    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif',
+    '--file=Dockerfile.jsonnet', '.'
+  ]
+
+images:
+- 'gcr.io/$PROJECT_ID/cbif'
+- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'


### PR DESCRIPTION
This change adds two custom Cloud Builder images that will be installed per-project by default. As a result of this change, once deployed, other M-lab repos using Cloud Builder can reference these builders in their own cloudbuild.yaml files, saving build time.

For example, the gcloud-jsonnet-cbif image should speed up k8s-support and siteinfo deploys by eliminating the requirement for creating a jsonnet environment.

The gloang-cbif image should make it possible to run golang tests and report coverage stats to coveralls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/19)
<!-- Reviewable:end -->
