### PR TITLE
Update link and allow curl to follow redirects

### DIFF
--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -29,7 +29,7 @@ COPY --from=cbif-go-builder  /go/bin/cbif /usr/bin/cbif
 COPY --from=jsonnet-go-builder  /go/bin/jsonnet /usr/bin/jsonnet-go
 COPY --from=jsonnet-cpp-builder /opt/jsonnet/jsonnet /usr/bin
 COPY --from=jsonnet-cpp-builder /opt/jsonnet/jsonnetfmt /usr/bin
-RUN curl -o /usr/bin/sjsonnet.jar https://github.com/lihaoyi/sjsonnet/releases/download/0.2.3/sjsonnet.jar
+RUN curl --location -o /usr/bin/sjsonnet.jar https://github.com/databricks/sjsonnet/releases/download/0.2.3/sjsonnet.jar
 RUN chmod 755 /usr/bin/sjsonnet.jar
 
 # Install additional dependencies.

--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -29,7 +29,7 @@ COPY --from=cbif-go-builder  /go/bin/cbif /usr/bin/cbif
 COPY --from=jsonnet-go-builder  /go/bin/jsonnet /usr/bin/jsonnet-go
 COPY --from=jsonnet-cpp-builder /opt/jsonnet/jsonnet /usr/bin
 COPY --from=jsonnet-cpp-builder /opt/jsonnet/jsonnetfmt /usr/bin
-RUN curl --location -o /usr/bin/sjsonnet.jar https://github.com/databricks/sjsonnet/releases/download/0.2.3/sjsonnet.jar
+RUN curl --location --output /usr/bin/sjsonnet.jar https://github.com/databricks/sjsonnet/releases/download/0.2.3/sjsonnet.jar
 RUN chmod 755 /usr/bin/sjsonnet.jar
 
 # Install additional dependencies.


### PR DESCRIPTION
This command was adapted from the step using `wget` in m-lab/siteinfo/Dockerfile -- but wget follows redirets automatically.

This change uses the correct source URL as well as allowing curl to follow redirects in the future.

With this change it should be possible to use the gcloud-jsonnet-cbif builder in siteinfo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/20)
<!-- Reviewable:end -->
