### PR TITLE
Add jq to gcloud-jsonnet image

### DIFF
--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -34,7 +34,7 @@ RUN chmod 755 /usr/bin/sjsonnet.jar
 
 # Install additional dependencies.
 RUN apt-get update
-RUN apt-get install -y dnsutils ca-certificates default-jre-headless make
+RUN apt-get install -y dnsutils ca-certificates default-jre-headless make jq
 RUN update-ca-certificates
 
 WORKDIR /


### PR DESCRIPTION
This change adds a new package `jq` to the gcloud+jsonnet builder image so k8s-support can use the per-project image for faster deploys.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/21)
<!-- Reviewable:end -->
