### PR TITLE
Builds a new Docker image for epoxy-images

### DIFF
--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update --fix-missing
+RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
+    lzma-dev liblzma-dev autopoint pkg-config libtool autotools-dev upx-ucl \
+    isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
+    strace cpio squashfs-tools curl lsb-release gawk \
+    mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
+    linux-source golang xorriso
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
+ENV GOROOT /usr/lib/go
+RUN mkdir /go
+ENV GOPATH /go
+# CGO_ENABLED=0 creates a statically linked binary.
+# The -ldflags drop another 2.5MB from the binary size.
+# -w    Omit the DWARF symbol table.
+# -s    Omit the symbol table and debug information.
+RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client
+

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -4,7 +4,7 @@ RUN apt-get update --fix-missing
 RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     lzma-dev liblzma-dev autopoint pkg-config libtool autotools-dev upx-ucl \
     isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
-    strace cpio squashfs-tools curl lsb-release gawk \
+    strace cpio squashfs-tools curl lsb-release gawk rsync \
     mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
     linux-source golang xorriso
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,6 +18,14 @@ steps:
     '--file=Dockerfile.jsonnet', '.'
   ]
 
+# Build epoxy-images image
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build',
+    '--tag=gcr.io/$PROJECT_ID/epoxy-images',
+    '--file=Dockerfile.epoxy-images', '.'
+  ]
+
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,3 +29,4 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'
+- 'gcr.io/$PROJECT_ID/epoxy-images'


### PR DESCRIPTION
epoxy-images are already slow, having to build the Docker image for Cloud Build slows them down even more. This PR adds a new Dockerfile for epoxy-images, and published it to gcr.io for use by other things, namely epoxy-images builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/22)
<!-- Reviewable:end -->
