### PR TITLE
add public discuss group roles

### DIFF
--- a/service-accounts/public_bigquery_user_dataset_level.yaml
+++ b/service-accounts/public_bigquery_user_dataset_level.yaml
@@ -1,7 +1,6 @@
 description: ' This role provides Discuss group users with access to specific datasets
   in the measurement-lab project. The role is applied to individual BQ datasets within
   BQ, by selecting the dataset and clicking "Share Dataset".'
-etag: BwWo6W3Gips=
 includedPermissions:
 - bigquery.datasets.get
 - bigquery.datasets.getIamPolicy
@@ -14,6 +13,5 @@ includedPermissions:
 - bigquery.tables.getData
 - bigquery.tables.list
 - resourcemanager.projects.get
-name: projects/measurement-lab/roles/public_bigquery_user_dataset_level
 stage: GA
 title: public-bigquery-user-dataset-level

--- a/service-accounts/public_bigquery_user_dataset_level.yaml
+++ b/service-accounts/public_bigquery_user_dataset_level.yaml
@@ -1,0 +1,19 @@
+description: ' This role provides Discuss group users with access to specific datasets
+  in the measurement-lab project. The role is applied to individual BQ datasets within
+  BQ, by selecting the dataset and clicking "Share Dataset".'
+etag: BwWo6W3Gips=
+includedPermissions:
+- bigquery.datasets.get
+- bigquery.datasets.getIamPolicy
+- bigquery.jobs.create
+- bigquery.jobs.list
+- bigquery.savedqueries.get
+- bigquery.savedqueries.list
+- bigquery.tables.export
+- bigquery.tables.get
+- bigquery.tables.getData
+- bigquery.tables.list
+- resourcemanager.projects.get
+name: projects/measurement-lab/roles/public_bigquery_user_dataset_level
+stage: GA
+title: public-bigquery-user-dataset-level

--- a/service-accounts/public_bigquery_user_project_level.yaml
+++ b/service-accounts/public_bigquery_user_project_level.yaml
@@ -1,0 +1,18 @@
+description: |-
+  Created to provide limited access to project resources for public bq users. Combined with a table level role this allows bq users subscribed to Discuss to:
+  - select measurement-lab project
+  - created jobs with the SDK
+  - save personal queries
+  - export data
+etag: BwWo6ZLG8WE=
+includedPermissions:
+- bigquery.jobs.create
+- bigquery.jobs.list
+- bigquery.savedqueries.get
+- bigquery.savedqueries.list
+- bigquery.tables.export
+- bigquery.tables.getData
+- resourcemanager.projects.get
+name: projects/measurement-lab/roles/public_bigquery_user_project_level
+stage: GA
+title: public-bigquery-user-project-level

--- a/service-accounts/public_bigquery_user_project_level.yaml
+++ b/service-accounts/public_bigquery_user_project_level.yaml
@@ -4,7 +4,6 @@ description: |-
   - created jobs with the SDK
   - save personal queries
   - export data
-etag: BwWo6ZLG8WE=
 includedPermissions:
 - bigquery.jobs.create
 - bigquery.jobs.list
@@ -13,6 +12,5 @@ includedPermissions:
 - bigquery.tables.export
 - bigquery.tables.getData
 - resourcemanager.projects.get
-name: projects/measurement-lab/roles/public_bigquery_user_project_level
 stage: GA
 title: public-bigquery-user-project-level


### PR DESCRIPTION
This PR adds two IAM roles used to provide limited project access and access to specific datasets to members of discuss@measurementlab.net

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/26)
<!-- Reviewable:end -->
