### PR TITLE
Sandbox six hour transfer

### DIFF
--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -46,7 +46,7 @@ steps:
 # has less data to move, and can complete more quickly.
 
 # 08:30:00 Configure daily pusher to local archive transfer.
-- name: gcp-config-cbif
+- name: gcp-config-cbif-0830
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   args: [
@@ -62,7 +62,7 @@ steps:
   ]
 
 # 11:30:00 Configure daily local archive to public archive transfer.
-- name: gcp-config-cbif
+- name: gcp-config-cbif-1130
   env:
   - PROJECT_IN=measurement-lab
   args: [
@@ -74,7 +74,7 @@ steps:
 
 
 # 14:30:00 Configure daily pusher to local archive transfer.
-- name: gcp-config-cbif
+- name: gcp-config-cbif-1430
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   args: [
@@ -90,7 +90,7 @@ steps:
   ]
 
 # 17:30:00 Configure daily local archive to public archive transfer.
-- name: gcp-config-cbif
+- name: gcp-config-cbif-1730
   env:
   - PROJECT_IN=measurement-lab
   args: [
@@ -102,7 +102,7 @@ steps:
 
 
 # 20:30:00 Configure daily pusher to local archive transfer.
-- name: gcp-config-cbif
+- name: gcp-config-cbif-2030
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   args: [
@@ -118,7 +118,7 @@ steps:
   ]
 
 # 23:30:00 Configure daily local archive to public archive transfer.
-- name: gcp-config-cbif
+- name: gcp-config-cbif-2330
   env:
   - PROJECT_IN=measurement-lab
   args: [

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -46,7 +46,7 @@ steps:
 # has less data to move, and can complete more quickly.
 
 # 08:30:00 Configure daily pusher to local archive transfer.
-- name: gcp-config-cbif-0830
+- name: gcp-config-cbif
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   args: [
@@ -62,7 +62,7 @@ steps:
   ]
 
 # 11:30:00 Configure daily local archive to public archive transfer.
-- name: gcp-config-cbif-1130
+- name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [
@@ -74,7 +74,7 @@ steps:
 
 
 # 14:30:00 Configure daily pusher to local archive transfer.
-- name: gcp-config-cbif-1430
+- name: gcp-config-cbif
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   args: [
@@ -90,7 +90,7 @@ steps:
   ]
 
 # 17:30:00 Configure daily local archive to public archive transfer.
-- name: gcp-config-cbif-1730
+- name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [
@@ -102,7 +102,7 @@ steps:
 
 
 # 20:30:00 Configure daily pusher to local archive transfer.
-- name: gcp-config-cbif-2030
+- name: gcp-config-cbif
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
   args: [
@@ -118,7 +118,7 @@ steps:
   ]
 
 # 23:30:00 Configure daily local archive to public archive transfer.
-- name: gcp-config-cbif-2330
+- name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -27,14 +27,18 @@ steps:
              'sync'
   ]
 
-# 03:30:00 Configure daily local archive to public archive transfer.
+# 04:00:00 Configure daily local archive to public archive transfer.
+# NOTE that this transfer is only 1.5 hours after the previous transfer.
+# The other transfers are staggered by 3 hours, and we should consider
+# making this one 3 hours as well, but that would increase the latency
+# before the data is available for parsing.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
-             '-time=03:30:00',
+             '-time=04:00:00',
              'sync'
   ]
 
@@ -57,14 +61,14 @@ steps:
              'sync'
   ]
 
-# 09:30:00 Configure daily local archive to public archive transfer.
+# 11:30:00 Configure daily local archive to public archive transfer.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
-             '-time=09:30:00',
+             '-time=11:30:00',
              'sync'
   ]
 
@@ -85,14 +89,14 @@ steps:
              'sync'
   ]
 
-# 15:30:00 Configure daily local archive to public archive transfer.
+# 17:30:00 Configure daily local archive to public archive transfer.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
-             '-time=15:30:00',
+             '-time=17:30:00',
              'sync'
   ]
 
@@ -113,14 +117,14 @@ steps:
              'sync'
   ]
 
-# 21:30:00 Configure daily local archive to public archive transfer.
+# 23:30:00 Configure daily local archive to public archive transfer.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
   args: [
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
-             '-time=21:30:00',
+             '-time=23:30:00',
              'sync'
   ]
 

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -38,6 +38,92 @@ steps:
              'sync'
   ]
 
+# Repeat transfers every 6 hours, so that the final transfer
+# has less data to move, and can complete more quickly.
+
+# 08:30:00 Configure daily pusher to local archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
+  args: [
+    'stctl', '-gcs.source=pusher-$PROJECT_ID',
+             '-gcs.target=archive-$PROJECT_ID',
+             '-time=08:30:00',
+             '-include=ndt',
+             '-include=host',
+             '-include=neubot',
+             '-include=utilization',
+             '-include=wehe',
+             'sync'
+  ]
+
+# 09:30:00 Configure daily local archive to public archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=measurement-lab
+  args: [
+    'stctl', '-gcs.source=archive-mlab-oti',
+             '-gcs.target=archive-measurement-lab',
+             '-time=09:30:00',
+             'sync'
+  ]
+
+
+# 14:30:00 Configure daily pusher to local archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
+  args: [
+    'stctl', '-gcs.source=pusher-$PROJECT_ID',
+             '-gcs.target=archive-$PROJECT_ID',
+             '-time=14:30:00',
+             '-include=ndt',
+             '-include=host',
+             '-include=neubot',
+             '-include=utilization',
+             '-include=wehe',
+             'sync'
+  ]
+
+# 15:30:00 Configure daily local archive to public archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=measurement-lab
+  args: [
+    'stctl', '-gcs.source=archive-mlab-oti',
+             '-gcs.target=archive-measurement-lab',
+             '-time=15:30:00',
+             'sync'
+  ]
+
+
+# 20:30:00 Configure daily pusher to local archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
+  args: [
+    'stctl', '-gcs.source=pusher-$PROJECT_ID',
+             '-gcs.target=archive-$PROJECT_ID',
+             '-time=20:30:00',
+             '-include=ndt',
+             '-include=host',
+             '-include=neubot',
+             '-include=utilization',
+             '-include=wehe',
+             'sync'
+  ]
+
+# 21:30:00 Configure daily local archive to public archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=measurement-lab
+  args: [
+    'stctl', '-gcs.source=archive-mlab-oti',
+             '-gcs.target=archive-measurement-lab',
+             '-time=21:30:00',
+             'sync'
+  ]
+
 # 04:30:00 Gardener or other jobs that depend on the public archive being up to date may run.
 # 04:30:00 Configure daily public archive to backup transfer.
 # NOTE: mlab-backups intentionally restricts access. This configuration is documentation.

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.14.0 h1:uMf5uLi4eQMRrMKhCplNik4U4H8Z6C1br3zOtAa/aDE=
 google.golang.org/api v0.14.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/api v0.15.0 h1:yzlyyDW/J0w8yNFJIhiAJy4kq74S+1DOLdawELNxFMA=
 google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=

--- a/internal/stctl/create.go
+++ b/internal/stctl/create.go
@@ -63,7 +63,7 @@ func getSpec(src, dest string, prefixes []string) *storagetransfer.TransferSpec 
 		spec.ObjectConditions = &storagetransfer.ObjectConditions{
 			IncludePrefixes: prefixes,
 			// Only files modified in the last 5 days.
-			MaxTimeElapsedSinceLastModification: "432000",
+			MaxTimeElapsedSinceLastModification: "432000s",
 		}
 	}
 	return spec

--- a/internal/stctl/create.go
+++ b/internal/stctl/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/pretty"
 
@@ -14,7 +15,7 @@ import (
 // Create creates a new storage transfer job.
 func (c *Command) Create(ctx context.Context) (*storagetransfer.TransferJob, error) {
 	spec := getSpec(c.SourceBucket, c.TargetBucket, c.Prefixes)
-	desc := getDesc(c.SourceBucket, c.TargetBucket)
+	desc := getDesc(c.SourceBucket, c.TargetBucket, c.StartTime)
 	ts := time.Now().UTC()
 	create := &storagetransfer.TransferJob{
 		Description: desc,
@@ -45,8 +46,8 @@ func (c *Command) Create(ctx context.Context) (*storagetransfer.TransferJob, err
 
 // getDesc returns the canonical description used to identify previously created
 // jobs. WARNING: Do not modify this format without adjusting existing configs to match.
-func getDesc(src, dest string) string {
-	return fmt.Sprintf("STCTL: daily copy of %s to %s", src, dest)
+func getDesc(src, dest string, start flagx.Time) string {
+	return fmt.Sprintf("STCTL: transfer %s -> %s at %s", src, dest, start)
 }
 
 func getSpec(src, dest string, prefixes []string) *storagetransfer.TransferSpec {

--- a/internal/stctl/create.go
+++ b/internal/stctl/create.go
@@ -62,6 +62,8 @@ func getSpec(src, dest string, prefixes []string) *storagetransfer.TransferSpec 
 	if prefixes != nil {
 		spec.ObjectConditions = &storagetransfer.ObjectConditions{
 			IncludePrefixes: prefixes,
+			// Only files modified in the last 5 days.
+			MaxTimeElapsedSinceLastModification: "432000",
 		}
 	}
 	return spec

--- a/internal/stctl/create_test.go
+++ b/internal/stctl/create_test.go
@@ -14,7 +14,7 @@ import (
 func TestCommand_Create(t *testing.T) {
 	ts := time.Now().UTC()
 	expected := &storagetransfer.TransferJob{
-		Description: "STCTL: daily copy of src-bucket to dest-bucket",
+		Description: "STCTL: transfer src-bucket -> dest-bucket at 02:10:00",
 		Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
 		ProjectId:   "fake-mlab-testing",
 		Schedule: &storagetransfer.Schedule{
@@ -38,7 +38,8 @@ func TestCommand_Create(t *testing.T) {
 				BucketName: "dest-bucket",
 			},
 			ObjectConditions: &storagetransfer.ObjectConditions{
-				IncludePrefixes: []string{"ndt"},
+				IncludePrefixes:                     []string{"ndt"},
+				MaxTimeElapsedSinceLastModification: "432000s",
 			},
 		},
 	}

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -23,7 +23,7 @@ func (c *Command) Sync(ctx context.Context) (*storagetransfer.TransferJob, error
 	notFound := fmt.Errorf("no matching job found")
 
 	// Generate canonical description from current config.
-	desc := getDesc(c.SourceBucket, c.TargetBucket)
+	desc := getDesc(c.SourceBucket, c.TargetBucket, c.StartTime)
 
 	// List jobs and find first that matches canonical description.
 	logx.Debug.Println("Listing jobs")

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -35,7 +35,7 @@ func TestCommand_Sync(t *testing.T) {
 							},
 							{
 								Name:        "transferOperations/description-matches-gcs-buckets",
-								Description: getDesc("fake-source", "fake-target"),
+								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
 								Schedule: &storagetransfer.Schedule{
 									ScheduleEndDate: nil,
 									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
@@ -82,7 +82,7 @@ func TestCommand_Sync(t *testing.T) {
 						TransferJobs: []*storagetransfer.TransferJob{
 							{
 								Name:        "transferOperations/description-matches-ObjectConditions-does-not",
-								Description: getDesc("fake-source", "fake-target"),
+								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
 								Schedule: &storagetransfer.Schedule{
 									ScheduleEndDate: nil,
 									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
@@ -170,7 +170,7 @@ func TestCommand_Sync(t *testing.T) {
 						TransferJobs: []*storagetransfer.TransferJob{
 							{
 								Name:        "transferOperations/description-matches",
-								Description: getDesc("fake-source", "fake-target"),
+								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
 								Schedule: &storagetransfer.Schedule{
 									ScheduleEndDate: nil,
 									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
@@ -200,7 +200,7 @@ func TestCommand_Sync(t *testing.T) {
 						TransferJobs: []*storagetransfer.TransferJob{
 							{
 								Name:        "transferOperations/description-matches",
-								Description: getDesc("fake-source", "fake-target"),
+								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
 								Schedule: &storagetransfer.Schedule{
 									ScheduleEndDate: nil,
 									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},


### PR DESCRIPTION
Add separate transfers every six hours.

It is hoped that this will make the transfers faster, so we don't miss the start of parsing.

Also restricts the transfer to files modified in the past 5 days.  Hopefully transfer service can use this to optimize the request.

NOTE: I haven't quite figured out how to create multiple requests.  Changed the description, but that doesn't seem to be adequate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/27)
<!-- Reviewable:end -->
