### PR TITLE
Add minFileAge and maxFileAge parameters

### DIFF
--- a/cmd/stctl/main.go
+++ b/cmd/stctl/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/m-lab/gcp-config/internal/stctl"
 	"github.com/m-lab/gcp-config/transfer"
@@ -36,6 +37,8 @@ var (
 	prefixes     flagx.StringArray
 	startTime    flagx.Time
 	afterDate    flagx.DateTime
+	minAge       time.Duration
+	maxAge       time.Duration
 )
 
 func init() {
@@ -45,6 +48,8 @@ func init() {
 	flag.Var(&prefixes, "include", "Only transfer files with given prefix. Default all prefixes. Can be specified multiple times.")
 	flag.Var(&startTime, "time", "Start daily transfer at this time (HH:MM:SS)")
 	flag.Var(&afterDate, "after", "Only list operations that ran after the given date. Default is all dates.")
+	flag.DurationVar(&minAge, "minFileAge", 0, "Minimum time since file modification")
+	flag.DurationVar(&maxAge, "maxFileAge", 0, "Maximum time since file modification")
 }
 
 var usageText = `
@@ -61,7 +66,7 @@ EXAMPLES
   stctl -project-id <project> operations <job name>
 
   stctl -project-id <project> create -gcs.source <bucket> -gcs.target <bucket> \
-    -time <HH:MM:SS> -include ndt -include host -include neubot -include utilization
+    -time <HH:MM:SS> -maxAge <duration> -minAge <duration> -include ndt -include host -include neubot -include utilization
 
   stctl -project-id <project> disable <job name>
 
@@ -100,6 +105,8 @@ func main() {
 		Prefixes:     prefixes,
 		StartTime:    startTime,
 		AfterDate:    afterDate.Time,
+		MinFileAge:   minAge.Truncate(time.Second),
+		MaxFileAge:   maxAge.Truncate(time.Second),
 		Output:       os.Stdout,
 	}
 

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -19,6 +19,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=02:30:00',
+             '-maxFileAge=12h',
              '-include=ndt',
              '-include=host',
              '-include=neubot',
@@ -39,6 +40,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=04:00:00',
+             '-maxFileAge=12h',
              'sync'
   ]
 
@@ -53,6 +55,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=08:30:00',
+             '-maxFileAge=12h',
              '-include=ndt',
              '-include=host',
              '-include=neubot',
@@ -69,11 +72,13 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=11:30:00',
+             '-maxFileAge=12h',
              'sync'
   ]
 
 
 # 14:30:00 Configure daily pusher to local archive transfer.
+# This one has no maxFileAge, so it should handle any stragglers
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
@@ -90,6 +95,7 @@ steps:
   ]
 
 # 17:30:00 Configure daily local archive to public archive transfer.
+# This one has no maxFileAge, so it should handle any stragglers
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
@@ -109,6 +115,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=20:30:00',
+             '-maxFileAge=12h',
              '-include=ndt',
              '-include=host',
              '-include=neubot',
@@ -125,6 +132,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=23:30:00',
+             '-maxFileAge=12h',
              'sync'
   ]
 

--- a/internal/stctl/command.go
+++ b/internal/stctl/command.go
@@ -49,6 +49,8 @@ type Command struct {
 	Prefixes     []string
 	StartTime    flagx.Time
 	AfterDate    time.Time
+	MinFileAge   time.Duration
+	MaxFileAge   time.Duration
 	Output       io.Writer
 }
 

--- a/internal/stctl/create.go
+++ b/internal/stctl/create.go
@@ -66,11 +66,11 @@ func getSpec(src, dest string, prefixes []string, minAge, maxAge time.Duration) 
 		spec.ObjectConditions = cond
 	}
 	if maxAge > 0 {
-		cond.MaxTimeElapsedSinceLastModification = fmt.Sprintf("%ds", maxAge/1000000000)
+		cond.MaxTimeElapsedSinceLastModification = fmt.Sprintf("%.0fs", maxAge.Seconds())
 		spec.ObjectConditions = cond
 	}
 	if minAge > 0 {
-		cond.MinTimeElapsedSinceLastModification = fmt.Sprintf("%ds", minAge/1000000000)
+		cond.MinTimeElapsedSinceLastModification = fmt.Sprintf("%.0fs", minAge.Seconds())
 		spec.ObjectConditions = cond
 	}
 	return spec

--- a/internal/stctl/create_test.go
+++ b/internal/stctl/create_test.go
@@ -40,6 +40,7 @@ func TestCommand_Create(t *testing.T) {
 			ObjectConditions: &storagetransfer.ObjectConditions{
 				IncludePrefixes:                     []string{"ndt"},
 				MaxTimeElapsedSinceLastModification: "432000s",
+				MinTimeElapsedSinceLastModification: "3600s",
 			},
 		},
 	}
@@ -58,6 +59,7 @@ func TestCommand_Create(t *testing.T) {
 				SourceBucket: "src-bucket",
 				TargetBucket: "dest-bucket",
 				MaxFileAge:   5 * 24 * time.Hour,
+				MinFileAge:   time.Hour,
 				Project:      "fake-mlab-testing",
 			},
 		},

--- a/internal/stctl/create_test.go
+++ b/internal/stctl/create_test.go
@@ -57,6 +57,7 @@ func TestCommand_Create(t *testing.T) {
 				StartTime:    flagx.Time{Hour: 2, Minute: 10},
 				SourceBucket: "src-bucket",
 				TargetBucket: "dest-bucket",
+				MaxFileAge:   5 * 24 * time.Hour,
 				Project:      "fake-mlab-testing",
 			},
 		},
@@ -75,10 +76,10 @@ func TestCommand_Create(t *testing.T) {
 			ctx := context.Background()
 			job, err := tt.c.Create(ctx)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Command.Create() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Command.Create(%s) error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
 			if diff := deep.Equal(job, expected); diff != nil && !tt.wantErr {
-				t.Errorf("Command.Create() returned and expected jobs differ; %v", diff)
+				t.Errorf("Command.Create(%s) returned and expected jobs differ; %v", tt.name, diff)
 			}
 		})
 	}

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -35,8 +35,8 @@ func (c *Command) Sync(ctx context.Context) (*storagetransfer.TransferJob, error
 			}
 			logx.Debug.Print(pretty.Sprint(job))
 			if desc == job.Description {
-				// Sync depends on the convention for storage transfer job managment where
-				// only a single transfer job exists between two buckets. So, the first
+				// Sync depends on the convention for storage transfer job management that
+				// each job has a unique description, so the first
 				// matching job should be the only matching job.
 				found = job
 				return nil

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -56,6 +56,7 @@ func TestCommand_Sync(t *testing.T) {
 				TargetBucket: "fake-target",
 				Prefixes:     []string{"a", "b"},
 				StartTime:    flagx.Time{Hour: 1, Minute: 2, Second: 3},
+				MaxFileAge:   5 * 24 * time.Hour,
 			},
 			expected: &storagetransfer.TransferJob{
 				Description: "STCTL: transfer fake-source -> fake-target at 01:02:03",
@@ -118,8 +119,7 @@ func TestCommand_Sync(t *testing.T) {
 					GcsDataSource: &storagetransfer.GcsData{BucketName: "fake-source"},
 					GcsDataSink:   &storagetransfer.GcsData{BucketName: "fake-target"},
 					ObjectConditions: &storagetransfer.ObjectConditions{
-						IncludePrefixes:                     []string{"a", "b"},
-						MaxTimeElapsedSinceLastModification: "432000s",
+						IncludePrefixes: []string{"a", "b"},
 					},
 				},
 				Status: "ENABLED",
@@ -224,15 +224,15 @@ func TestCommand_Sync(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	for i, tt := range tests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			job, err := tt.c.Sync(ctx)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Command.Sync() %d error = %v, wantErr %v", i, err, tt.wantErr)
+				t.Errorf("Command.Sync() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if diff := deep.Equal(job, tt.expected); diff != nil && !tt.wantErr {
-				t.Errorf("Command.Sync() %d job did not match expected;\n%s", i, strings.Join(diff, "\n"))
+				t.Errorf("Command.Sync() job did not match expected;\n%s", strings.Join(diff, "\n"))
 			}
 		})
 	}

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -45,6 +45,7 @@ func TestCommand_Sync(t *testing.T) {
 									ObjectConditions: &storagetransfer.ObjectConditions{
 										IncludePrefixes:                     []string{"a", "b"},
 										MaxTimeElapsedSinceLastModification: "432000s",
+										MinTimeElapsedSinceLastModification: "3600s",
 									},
 								},
 							},
@@ -56,6 +57,7 @@ func TestCommand_Sync(t *testing.T) {
 				Prefixes:     []string{"a", "b"},
 				StartTime:    flagx.Time{Hour: 1, Minute: 2, Second: 3},
 				MaxFileAge:   5 * 24 * time.Hour,
+				MinFileAge:   time.Hour,
 			},
 			expected: &storagetransfer.TransferJob{
 				Description: "STCTL: transfer fake-source -> fake-target at 01:02:03",
@@ -69,6 +71,7 @@ func TestCommand_Sync(t *testing.T) {
 					ObjectConditions: &storagetransfer.ObjectConditions{
 						IncludePrefixes:                     []string{"a", "b"},
 						MaxTimeElapsedSinceLastModification: "432000s",
+						MinTimeElapsedSinceLastModification: "3600s",
 					},
 				},
 			},

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -29,9 +29,8 @@ func TestCommand_Sync(t *testing.T) {
 							{
 								Name:        "transferOperations/ignore-job-with-end-date",
 								Description: "ignore-job-with-end-date",
-								Schedule: &storagetransfer.Schedule{
-									ScheduleEndDate: &storagetransfer.Date{Day: 1, Month: 2, Year: 2019},
-								},
+								// Schedule can be empty because there is no TransferSpec?
+								Schedule: &storagetransfer.Schedule{},
 							},
 							{
 								Name:        "transferOperations/description-matches-gcs-buckets",
@@ -88,19 +87,13 @@ func TestCommand_Sync(t *testing.T) {
 							{
 								Name:        "transferOperations/description-matches-ObjectConditions-does-not",
 								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
-								Schedule: &storagetransfer.Schedule{
-									ScheduleEndDate: nil,
-									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
-								},
-								TransferSpec: &storagetransfer.TransferSpec{
-									GcsDataSource:    &storagetransfer.GcsData{BucketName: "fake-source"},
-									GcsDataSink:      &storagetransfer.GcsData{BucketName: "fake-target"},
-									ObjectConditions: &storagetransfer.ObjectConditions{}, // Empty object conditions specified.
-								},
+								// Schedule can be empty because there is no TransferSpec?
+								Schedule: &storagetransfer.Schedule{},
 							},
 						},
 					},
 					// a fake job that is disabled.
+					// With this fake job, we don't need detail in TransferJobs
 					job: &storagetransfer.TransferJob{},
 				},
 			},
@@ -157,6 +150,7 @@ func TestCommand_Sync(t *testing.T) {
 			name: "error-list-jobs",
 			c: &Command{
 				Client: &fakeTJ{
+					// With listErr, we don't need any other client detail
 					listErr: errors.New("Fake list error"),
 				},
 			},
@@ -176,21 +170,15 @@ func TestCommand_Sync(t *testing.T) {
 							{
 								Name:        "transferOperations/description-matches",
 								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
-								Schedule: &storagetransfer.Schedule{
-									ScheduleEndDate: nil,
-									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
-								},
-								TransferSpec: &storagetransfer.TransferSpec{
-									GcsDataSource:    &storagetransfer.GcsData{BucketName: "fake-source"},
-									GcsDataSink:      &storagetransfer.GcsData{BucketName: "fake-target"},
-									ObjectConditions: &storagetransfer.ObjectConditions{IncludePrefixes: []string{"c", "d"}}, // IncludePrefixes do not match command.Prefixes.
-								},
+								// Schedule can be empty because there is no TransferSpec?
+								Schedule: &storagetransfer.Schedule{},
 							},
 						},
 					},
 					getErr: errors.New("fake get error causes Disable() to fail"),
 				},
 			},
+			// With true  wantErr, Schedule can be empty, and TransferSpec is not needed.
 			wantErr: true,
 		},
 		{
@@ -206,21 +194,15 @@ func TestCommand_Sync(t *testing.T) {
 							{
 								Name:        "transferOperations/description-matches",
 								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 3, Minute: 2, Second: 1}),
-								Schedule: &storagetransfer.Schedule{
-									ScheduleEndDate: nil,
-									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
-								},
-								TransferSpec: &storagetransfer.TransferSpec{
-									GcsDataSource:    &storagetransfer.GcsData{BucketName: "fake-source"},
-									GcsDataSink:      &storagetransfer.GcsData{BucketName: "fake-target"},
-									ObjectConditions: &storagetransfer.ObjectConditions{},
-								},
+								// Schedule can be empty because there is no TransferSpec?
+								Schedule: &storagetransfer.Schedule{},
 							},
 						},
 					},
 					getErr: errors.New("fake get error causes Disable() to fail"),
 				},
 			},
+			// With true  wantErr, Schedule can be empty, and TransferSpec is not needed.
 			wantErr: true,
 		},
 	}
@@ -231,6 +213,7 @@ func TestCommand_Sync(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Command.Sync() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			// This only runs when !wantErr.  Otherwise, the fake job is never referenced.
 			if diff := deep.Equal(job, tt.expected); diff != nil && !tt.wantErr {
 				t.Errorf("Command.Sync() job did not match expected;\n%s", strings.Join(diff, "\n"))
 			}


### PR DESCRIPTION
This adds CLI parameters to allow filtering of files based on last mod time.

We hope that this will allow DataTransfer service to be more efficient than if it has to review the entire history.
The config file now imposes 12h age restrictions on 3 of the 4 transfers. The mid-day transfer has NO age
restriction, so it will handle any old files that were missed in recent transfers.
Q: Should we add a liberal limit for the mid-day transfer, maybe one week or one month?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/30)
<!-- Reviewable:end -->
