### PR TITLE
change minFileAge to one minute

### DIFF
--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -27,7 +27,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=02:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=12h',
              '-include=ndt',
              '-include=host',
@@ -49,7 +49,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=04:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=12h',
              'sync'
   ]
@@ -65,7 +65,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=08:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=12h',
              '-include=ndt',
              '-include=host',
@@ -83,7 +83,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=10:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=12h',
              'sync'
   ]
@@ -101,7 +101,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=14:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=168h',  # 7 days
              '-include=ndt',
              '-include=host',
@@ -121,7 +121,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=16:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=192h',  # 8 days
              'sync'
   ]
@@ -135,7 +135,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=20:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=12h',
              '-include=ndt',
              '-include=host',
@@ -153,7 +153,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=22:30:00',
-             '-minFileAge=10m',
+             '-minFileAge=1m',
              '-maxFileAge=12h',
              'sync'
   ]


### PR DESCRIPTION
Looks like the minFileAge of 10 minutes causes the transfer to drag out longer than is useful.  Change to 1 minute, to minimize the long tail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/32)
<!-- Reviewable:end -->
