### PR TITLE
Add delete after transfer option to sync command

### DIFF
--- a/cmd/stctl/main.go
+++ b/cmd/stctl/main.go
@@ -108,6 +108,7 @@ func main() {
 		MinFileAge:   minAge.Truncate(time.Second),
 		MaxFileAge:   maxAge.Truncate(time.Second),
 		Output:       os.Stdout,
+		// TODO - add Delete option
 	}
 
 	op := mustArg(0)

--- a/internal/stctl/command.go
+++ b/internal/stctl/command.go
@@ -42,16 +42,17 @@ type TransferJob interface {
 
 // Command executes stctl actions.
 type Command struct {
-	Client       TransferJob
-	Project      string
-	SourceBucket string
-	TargetBucket string
-	Prefixes     []string
-	StartTime    flagx.Time
-	AfterDate    time.Time
-	MinFileAge   time.Duration
-	MaxFileAge   time.Duration
-	Output       io.Writer
+	Client              TransferJob
+	Project             string
+	SourceBucket        string
+	TargetBucket        string
+	Prefixes            []string
+	StartTime           flagx.Time
+	AfterDate           time.Time
+	MinFileAge          time.Duration
+	MaxFileAge          time.Duration
+	DeleteAfterTransfer bool
+	Output              io.Writer
 }
 
 // ListJobs lists enabled transfer jobs.

--- a/internal/stctl/command_test.go
+++ b/internal/stctl/command_test.go
@@ -105,6 +105,9 @@ func TestCommand_ListJobs(t *testing.T) {
 									ObjectConditions: &storagetransfer.ObjectConditions{
 										IncludePrefixes: []string{"a", "b"},
 									},
+									TransferOptions: &storagetransfer.TransferOptions{
+										DeleteObjectsFromSourceAfterTransfer: true,
+									},
 								},
 							},
 						},
@@ -162,6 +165,9 @@ func TestCommand_ListOperations(t *testing.T) {
 										},
 										ObjectConditions: &storagetransfer.ObjectConditions{
 											IncludePrefixes: []string{"ndt"},
+										},
+										TransferOptions: &storagetransfer.TransferOptions{
+											//DeleteObjectsFromSourceAfterTransfer: true,
 										},
 									},
 									Start: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),

--- a/internal/stctl/command_test.go
+++ b/internal/stctl/command_test.go
@@ -166,9 +166,6 @@ func TestCommand_ListOperations(t *testing.T) {
 										ObjectConditions: &storagetransfer.ObjectConditions{
 											IncludePrefixes: []string{"ndt"},
 										},
-										TransferOptions: &storagetransfer.TransferOptions{
-											//DeleteObjectsFromSourceAfterTransfer: true,
-										},
 									},
 									Start: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
 									End:   time.Date(2019, time.January, 1, 1, 0, 0, 0, time.UTC),

--- a/internal/stctl/create.go
+++ b/internal/stctl/create.go
@@ -14,7 +14,7 @@ import (
 
 // Create creates a new storage transfer job.
 func (c *Command) Create(ctx context.Context) (*storagetransfer.TransferJob, error) {
-	spec := getSpec(c.SourceBucket, c.TargetBucket, c.Prefixes, c.MinFileAge, c.MaxFileAge, c.DeleteAfterTransfer)
+	spec := c.getSpec()
 	desc := getDesc(c.SourceBucket, c.TargetBucket, c.StartTime)
 	ts := time.Now().UTC()
 	create := &storagetransfer.TransferJob{
@@ -48,36 +48,4 @@ func (c *Command) Create(ctx context.Context) (*storagetransfer.TransferJob, err
 // jobs. WARNING: Do not modify this format without adjusting existing configs to match.
 func getDesc(src, dest string, start flagx.Time) string {
 	return fmt.Sprintf("STCTL: transfer %s -> %s at %s", src, dest, start)
-}
-
-func getSpec(src, dest string, prefixes []string, minAge, maxAge time.Duration, deleteAfterTransfer bool) storagetransfer.TransferSpec {
-	spec := storagetransfer.TransferSpec{
-		GcsDataSource: &storagetransfer.GcsData{
-			BucketName: src,
-		},
-		GcsDataSink: &storagetransfer.GcsData{
-			BucketName: dest,
-		},
-	}
-
-	cond := &storagetransfer.ObjectConditions{}
-	if prefixes != nil {
-		cond.IncludePrefixes = prefixes
-		spec.ObjectConditions = cond
-	}
-	if maxAge > 0 {
-		cond.MaxTimeElapsedSinceLastModification = fmt.Sprintf("%.0fs", maxAge.Seconds())
-		spec.ObjectConditions = cond
-	}
-	if minAge > 0 {
-		cond.MinTimeElapsedSinceLastModification = fmt.Sprintf("%.0fs", minAge.Seconds())
-		spec.ObjectConditions = cond
-	}
-
-	if deleteAfterTransfer {
-		spec.TransferOptions = &storagetransfer.TransferOptions{
-			DeleteObjectsFromSourceAfterTransfer: true,
-		}
-	}
-	return spec
 }

--- a/internal/stctl/create_test.go
+++ b/internal/stctl/create_test.go
@@ -13,54 +13,105 @@ import (
 
 func TestCommand_Create(t *testing.T) {
 	ts := time.Now().UTC()
-	expected := &storagetransfer.TransferJob{
-		Description: "STCTL: transfer src-bucket -> dest-bucket at 02:10:00",
-		Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
-		ProjectId:   "fake-mlab-testing",
-		Schedule: &storagetransfer.Schedule{
-			ScheduleEndDate: (*storagetransfer.Date)(nil),
-			ScheduleStartDate: &storagetransfer.Date{
-				Day:   int64(ts.Day()),
-				Month: int64(ts.Month()),
-				Year:  int64(ts.Year()),
-			},
-			StartTimeOfDay: &storagetransfer.TimeOfDay{
-				Hours:   2,
-				Minutes: 10,
-			},
-		},
-		Status: "ENABLED",
-		TransferSpec: &storagetransfer.TransferSpec{
-			GcsDataSource: &storagetransfer.GcsData{
-				BucketName: "src-bucket",
-			},
-			GcsDataSink: &storagetransfer.GcsData{
-				BucketName: "dest-bucket",
-			},
-			ObjectConditions: &storagetransfer.ObjectConditions{
-				IncludePrefixes:                     []string{"ndt"},
-				MaxTimeElapsedSinceLastModification: "432000s",
-				MinTimeElapsedSinceLastModification: "3600s",
-			},
-		},
-	}
-
 	tests := []struct {
-		name    string
-		c       *Command
-		wantErr bool
+		name         string
+		c            *Command
+		expect       storagetransfer.TransferJob
+		shouldDelete bool
+		wantErr      bool
 	}{
 		{
-			name: "success",
+			name: "success-no-delete",
 			c: &Command{
-				Client:       &fakeTJ{},
-				Prefixes:     []string{"ndt"},
-				StartTime:    flagx.Time{Hour: 2, Minute: 10},
-				SourceBucket: "src-bucket",
-				TargetBucket: "dest-bucket",
-				MaxFileAge:   5 * 24 * time.Hour,
-				MinFileAge:   time.Hour,
-				Project:      "fake-mlab-testing",
+				Client:              &fakeTJ{},
+				Prefixes:            []string{"ndt"},
+				StartTime:           flagx.Time{Hour: 2, Minute: 10},
+				SourceBucket:        "src-bucket",
+				TargetBucket:        "dest-bucket",
+				MaxFileAge:          5 * 24 * time.Hour,
+				MinFileAge:          time.Hour,
+				Project:             "fake-mlab-testing",
+				DeleteAfterTransfer: false,
+			},
+			expect: storagetransfer.TransferJob{
+				Description: "STCTL: transfer src-bucket -> dest-bucket at 02:10:00",
+				Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
+				ProjectId:   "fake-mlab-testing",
+				Schedule: &storagetransfer.Schedule{
+					ScheduleEndDate: (*storagetransfer.Date)(nil),
+					ScheduleStartDate: &storagetransfer.Date{
+						Day:   int64(ts.Day()),
+						Month: int64(ts.Month()),
+						Year:  int64(ts.Year()),
+					},
+					StartTimeOfDay: &storagetransfer.TimeOfDay{
+						Hours:   2,
+						Minutes: 10,
+					},
+				},
+				Status: "ENABLED",
+				TransferSpec: &storagetransfer.TransferSpec{
+					GcsDataSource: &storagetransfer.GcsData{
+						BucketName: "src-bucket",
+					},
+					GcsDataSink: &storagetransfer.GcsData{
+						BucketName: "dest-bucket",
+					},
+					ObjectConditions: &storagetransfer.ObjectConditions{
+						IncludePrefixes:                     []string{"ndt"},
+						MaxTimeElapsedSinceLastModification: "432000s",
+						MinTimeElapsedSinceLastModification: "3600s",
+					},
+				},
+			},
+		},
+
+		{
+			name: "success-delete-after-transfer",
+			c: &Command{
+				Client:              &fakeTJ{},
+				Prefixes:            []string{"ndt"},
+				StartTime:           flagx.Time{Hour: 2, Minute: 10},
+				SourceBucket:        "src-bucket",
+				TargetBucket:        "dest-bucket",
+				MaxFileAge:          5 * 24 * time.Hour,
+				MinFileAge:          time.Hour,
+				Project:             "fake-mlab-testing",
+				DeleteAfterTransfer: true,
+			},
+			expect: storagetransfer.TransferJob{
+				Description: "STCTL: transfer src-bucket -> dest-bucket at 02:10:00",
+				Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
+				ProjectId:   "fake-mlab-testing",
+				Schedule: &storagetransfer.Schedule{
+					ScheduleEndDate: (*storagetransfer.Date)(nil),
+					ScheduleStartDate: &storagetransfer.Date{
+						Day:   int64(ts.Day()),
+						Month: int64(ts.Month()),
+						Year:  int64(ts.Year()),
+					},
+					StartTimeOfDay: &storagetransfer.TimeOfDay{
+						Hours:   2,
+						Minutes: 10,
+					},
+				},
+				Status: "ENABLED",
+				TransferSpec: &storagetransfer.TransferSpec{
+					GcsDataSource: &storagetransfer.GcsData{
+						BucketName: "src-bucket",
+					},
+					GcsDataSink: &storagetransfer.GcsData{
+						BucketName: "dest-bucket",
+					},
+					ObjectConditions: &storagetransfer.ObjectConditions{
+						IncludePrefixes:                     []string{"ndt"},
+						MaxTimeElapsedSinceLastModification: "432000s",
+						MinTimeElapsedSinceLastModification: "3600s",
+					},
+					TransferOptions: &storagetransfer.TransferOptions{
+						DeleteObjectsFromSourceAfterTransfer: true,
+					},
+				},
 			},
 		},
 		{
@@ -80,7 +131,7 @@ func TestCommand_Create(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Command.Create(%s) error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
-			if diff := deep.Equal(job, expected); diff != nil && !tt.wantErr {
+			if diff := deep.Equal(job, &tt.expect); diff != nil && !tt.wantErr {
 				t.Errorf("Command.Create(%s) returned and expected jobs differ; %v", tt.name, diff)
 			}
 		})

--- a/internal/stctl/export_test.go
+++ b/internal/stctl/export_test.go
@@ -1,5 +1,11 @@
 package stctl
 
+// These aliases allow unit tests in stctl_test package to access unexported items.
 type JobMetadata = jobMetadata
 
-var GetDesc = getDesc
+var (
+	ErrNotFound = errNotFound
+	GetDesc     = getDesc
+	Find        = (*Command).find
+	SpecMatches = (*Command).specMatches
+)

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -104,8 +104,11 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 		return false
 	}
 	cond := job.TransferSpec.ObjectConditions
-	if job.TransferSpec.ObjectConditions == nil ||
-		!includesEqual(cond.IncludePrefixes, c.Prefixes) ||
+	if cond == nil {
+		if len(c.Prefixes) > 0 || c.MaxFileAge > 0 || c.MinFileAge > 0 {
+			return false
+		}
+	} else if !includesEqual(cond.IncludePrefixes, c.Prefixes) ||
 		fmt.Sprintf("%0.fs", c.MaxFileAge.Seconds()) != cond.MaxTimeElapsedSinceLastModification ||
 		fmt.Sprintf("%0.fs", c.MinFileAge.Seconds()) != cond.MinTimeElapsedSinceLastModification {
 		return false

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -18,10 +18,12 @@ var getDesc = stctl.GetDesc
 func TestCommand_Sync(t *testing.T) {
 	ts := time.Now().UTC()
 	tests := []struct {
-		name     string
-		c        *Command
-		expected *storagetransfer.TransferJob
-		wantErr  bool
+		name        string
+		c           *Command
+		expected    *storagetransfer.TransferJob
+		wantErr     bool
+		shouldFind  bool // The specified job should be found in the client
+		shouldMatch bool // The specified job should match the existing job.
 	}{
 		{
 			name: "success-job-found-specs-match",
@@ -51,18 +53,24 @@ func TestCommand_Sync(t *testing.T) {
 										MaxTimeElapsedSinceLastModification: "432000s",
 										MinTimeElapsedSinceLastModification: "3600s",
 									},
+									TransferOptions: &storagetransfer.TransferOptions{
+										DeleteObjectsFromSourceAfterTransfer: true,
+									},
 								},
 							},
 						},
 					},
 				},
-				SourceBucket: "fake-source",
-				TargetBucket: "fake-target",
-				Prefixes:     []string{"a", "b"},
-				StartTime:    flagx.Time{Hour: 1, Minute: 2, Second: 3},
-				MaxFileAge:   5 * 24 * time.Hour,
-				MinFileAge:   time.Hour,
+				SourceBucket:        "fake-source",
+				TargetBucket:        "fake-target",
+				Prefixes:            []string{"a", "b"},
+				StartTime:           flagx.Time{Hour: 1, Minute: 2, Second: 3},
+				MaxFileAge:          5 * 24 * time.Hour,
+				MinFileAge:          time.Hour,
+				DeleteAfterTransfer: true,
 			},
+			shouldFind:  true,
+			shouldMatch: true,
 			expected: &storagetransfer.TransferJob{
 				Description: "STCTL: transfer fake-source -> fake-target at 01:02:03",
 				Name:        "transferOperations/description-matches-gcs-buckets",
@@ -77,6 +85,9 @@ func TestCommand_Sync(t *testing.T) {
 						MaxTimeElapsedSinceLastModification: "432000s",
 						MinTimeElapsedSinceLastModification: "3600s",
 					},
+					TransferOptions: &storagetransfer.TransferOptions{
+						DeleteObjectsFromSourceAfterTransfer: true,
+					},
 				},
 			},
 		},
@@ -87,6 +98,7 @@ func TestCommand_Sync(t *testing.T) {
 				TargetBucket: "fake-target",
 				Prefixes:     []string{"a", "b"},
 				StartTime:    flagx.Time{Hour: 1, Minute: 2, Second: 3},
+				// DeleteAfterTransfer: true,
 				Client: &fakeTJ{
 					// fake jobs that are listed to search for one that matches the current Command spec.
 					listJobResp: &storagetransfer.ListTransferJobsResponse{
@@ -110,6 +122,7 @@ func TestCommand_Sync(t *testing.T) {
 					job: &storagetransfer.TransferJob{},
 				},
 			},
+			shouldFind: true,
 			expected: &storagetransfer.TransferJob{
 				Description: "STCTL: transfer fake-source -> fake-target at 01:02:03",
 				Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
@@ -197,7 +210,8 @@ func TestCommand_Sync(t *testing.T) {
 					getErr: errors.New("fake get error causes Disable() to fail"),
 				},
 			},
-			wantErr: true,
+			shouldFind: true,
+			wantErr:    true,
 		},
 		{
 			name: "error-found-and-disable-error-different-start-times",
@@ -220,14 +234,29 @@ func TestCommand_Sync(t *testing.T) {
 					getErr: errors.New("fake get error causes Disable() to fail"),
 				},
 			},
-			// With true  wantErr, Schedule can be empty, and TransferSpec is not needed.
+			// With true wantErr, Schedule can be empty, and TransferSpec is not needed.
 			// This does not impact test coverage.
-			wantErr: true,
+			wantErr:    true,
+			shouldFind: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			found, err := tt.c.find(ctx)
+			if !tt.wantErr && err != errNotFound && err != nil {
+				t.Errorf("Command.Sync() error = %v", err)
+			}
+			if (found != nil) != tt.shouldFind {
+				t.Errorf("Command.Sync() found = %v, shouldFind = %v", found, tt.shouldFind)
+			}
+			if found != nil {
+				matches := tt.c.specMatches(found)
+				if matches != tt.shouldMatch {
+					t.Errorf("Command.Sync() matches = %v, shouldMatch = %v", matches, tt.shouldMatch)
+				}
+			}
+
 			job, err := tt.c.Sync(ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Command.Sync() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -243,15 +243,15 @@ func TestCommand_Sync(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			found, err := tt.c.find(ctx)
-			if !tt.wantErr && err != errNotFound && err != nil {
+			found, err := stctl.Find(tt.c, ctx)
+			if !tt.wantErr && err != stctl.ErrNotFound && err != nil {
 				t.Errorf("Command.Sync() error = %v", err)
 			}
 			if (found != nil) != tt.shouldFind {
 				t.Errorf("Command.Sync() found = %v, shouldFind = %v", found, tt.shouldFind)
 			}
 			if found != nil {
-				matches := tt.c.specMatches(found)
+				matches := stctl.SpecMatches(tt.c, found)
 				if matches != tt.shouldMatch {
 					t.Errorf("Command.Sync() matches = %v, shouldMatch = %v", matches, tt.shouldMatch)
 				}

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -98,7 +98,6 @@ func TestCommand_Sync(t *testing.T) {
 				TargetBucket: "fake-target",
 				Prefixes:     []string{"a", "b"},
 				StartTime:    flagx.Time{Hour: 1, Minute: 2, Second: 3},
-				// DeleteAfterTransfer: true,
 				Client: &fakeTJ{
 					// fake jobs that are listed to search for one that matches the current Command spec.
 					listJobResp: &storagetransfer.ListTransferJobsResponse{

--- a/internal/stctl/sync_test.go
+++ b/internal/stctl/sync_test.go
@@ -145,6 +145,108 @@ func TestCommand_Sync(t *testing.T) {
 			},
 		},
 		{
+			name: "success-delete-mismatch-disable-and-create",
+			c: &Command{
+				SourceBucket:        "fake-source",
+				TargetBucket:        "fake-target",
+				StartTime:           flagx.Time{Hour: 1, Minute: 2, Second: 3},
+				DeleteAfterTransfer: true,
+				Client: &fakeTJ{
+					// fake jobs that are listed to search for one that matches the current Command spec.
+					listJobResp: &storagetransfer.ListTransferJobsResponse{
+						TransferJobs: []*storagetransfer.TransferJob{
+							{
+								Name:        "transferOperations/description-matches-delete-option-does-not",
+								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
+								Schedule: &storagetransfer.Schedule{
+									ScheduleEndDate: nil,
+									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
+								},
+								TransferSpec: &storagetransfer.TransferSpec{
+									GcsDataSource: &storagetransfer.GcsData{BucketName: "fake-source"},
+									GcsDataSink:   &storagetransfer.GcsData{BucketName: "fake-target"},
+								},
+							},
+						},
+					},
+					// a fake job that is disabled.
+					job: &storagetransfer.TransferJob{},
+				},
+			},
+			shouldFind: true,
+			expected: &storagetransfer.TransferJob{
+				Description: "STCTL: transfer fake-source -> fake-target at 01:02:03",
+				Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
+				Schedule: &storagetransfer.Schedule{
+					StartTimeOfDay: &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
+					ScheduleStartDate: &storagetransfer.Date{
+						Day:   int64(ts.Day()),
+						Month: int64(ts.Month()),
+						Year:  int64(ts.Year()),
+					},
+				},
+				TransferSpec: &storagetransfer.TransferSpec{
+					GcsDataSource: &storagetransfer.GcsData{BucketName: "fake-source"},
+					GcsDataSink:   &storagetransfer.GcsData{BucketName: "fake-target"},
+					TransferOptions: &storagetransfer.TransferOptions{
+						DeleteObjectsFromSourceAfterTransfer: true,
+					},
+				},
+				Status: "ENABLED",
+			},
+		},
+		{
+			name: "success-nil-object-cond-disable-and-create",
+			c: &Command{
+				SourceBucket: "fake-source",
+				TargetBucket: "fake-target",
+				Prefixes:     []string{"a", "b"},
+				StartTime:    flagx.Time{Hour: 1, Minute: 2, Second: 3},
+				Client: &fakeTJ{
+					// fake jobs that are listed to search for one that matches the current Command spec.
+					listJobResp: &storagetransfer.ListTransferJobsResponse{
+						TransferJobs: []*storagetransfer.TransferJob{
+							{
+								Name:        "transferOperations/nil-object-cond",
+								Description: getDesc("fake-source", "fake-target", flagx.Time{Hour: 1, Minute: 2, Second: 3}),
+								Schedule: &storagetransfer.Schedule{
+									ScheduleEndDate: nil,
+									StartTimeOfDay:  &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
+								},
+								TransferSpec: &storagetransfer.TransferSpec{
+									GcsDataSource: &storagetransfer.GcsData{BucketName: "fake-source"},
+									GcsDataSink:   &storagetransfer.GcsData{BucketName: "fake-target"},
+								},
+							},
+						},
+					},
+					// a fake job that is disabled.
+					job: &storagetransfer.TransferJob{},
+				},
+			},
+			shouldFind: true,
+			expected: &storagetransfer.TransferJob{
+				Description: "STCTL: transfer fake-source -> fake-target at 01:02:03",
+				Name:        "THIS-IS-A-FAKE-ASSIGNED-JOB-NAME",
+				Schedule: &storagetransfer.Schedule{
+					StartTimeOfDay: &storagetransfer.TimeOfDay{Hours: 1, Minutes: 2, Seconds: 3},
+					ScheduleStartDate: &storagetransfer.Date{
+						Day:   int64(ts.Day()),
+						Month: int64(ts.Month()),
+						Year:  int64(ts.Year()),
+					},
+				},
+				TransferSpec: &storagetransfer.TransferSpec{
+					GcsDataSource: &storagetransfer.GcsData{BucketName: "fake-source"},
+					GcsDataSink:   &storagetransfer.GcsData{BucketName: "fake-target"},
+					ObjectConditions: &storagetransfer.ObjectConditions{
+						IncludePrefixes: []string{"a", "b"},
+					},
+				},
+				Status: "ENABLED",
+			},
+		},
+		{
 			name: "success-job-not-found-then-created",
 			c: &Command{
 				SourceBucket: "source",


### PR DESCRIPTION
This is needed to configure transfer rules, particularly from pusher to other buckets.

This does NOT yet change the configuration - just adds the capability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/34)
<!-- Reviewable:end -->
