### PR TITLE
Adds cloud-deployment dir with YAML spec for creating logs-based-metrics

### DIFF
--- a/cloud-deployment/README.md
+++ b/cloud-deployment/README.md
@@ -1,0 +1,22 @@
+# Google Cloud Deployment Manager
+
+This directory contains YAML spec files suitable for creating [Google Cloud
+Deployment Manager](https://cloud.google.com/deployment-manager) objects in
+GCP. Each YAML file should contain only a single resource type (e.g., service
+accounts, logs-based metrics, etc.)
+
+## Deployment
+
+Deployment of these resources can be done with something like:
+
+```
+gcloud deployment-manager deployments create <deployment-name> \
+  --config <yaml-file> --project <project>
+```
+
+For example:
+
+```
+gcloud deployment-manager deployments create logs-based-metrics \
+  --config logs-based-metrics.yaml --project mlab-sandbox
+```

--- a/cloud-deployment/logs-based-metrics.yaml
+++ b/cloud-deployment/logs-based-metrics.yaml
@@ -1,0 +1,20 @@
+resources:
+- name: platform-cluster-kernel-log-priorities
+  type: logging.v2.metric
+  properties:
+    description: Platform cluster kernel log message priorities
+    filter: |
+      resource.type="generic_node" resource.labels.location="mlab-sandbox" jsonPayload.SYSLOG_IDENTIFIER="kernel"
+    labelExtractors:
+      priority: EXTRACT(jsonPayload.PRIORITY)
+    metricDescriptor:
+      description: Platform cluster kernel log message priorities
+      labels:
+      - description: Priority
+        key: priority
+      metricKind: DELTA
+      name: platform-cluster-kernel-log-priorities
+      type: custom.googleapis.com/logs-based-metrics/platform-cluster-kernel-log_priorities
+      unit: '1'
+      valueType: INT64
+    metric: platform-cluster-kernel-log-priorities

--- a/cloud-deployment/logs-based-metrics.yaml
+++ b/cloud-deployment/logs-based-metrics.yaml
@@ -4,7 +4,7 @@ resources:
   properties:
     description: Platform cluster kernel log message priorities
     filter: |
-      resource.type="generic_node" resource.labels.location="mlab-sandbox" jsonPayload.SYSLOG_IDENTIFIER="kernel"
+      resource.type="generic_node" jsonPayload.SYSLOG_IDENTIFIER="kernel"
     labelExtractors:
       priority: EXTRACT(jsonPayload.PRIORITY)
     metricDescriptor:


### PR DESCRIPTION
This PR creates a new subdirectory to contain Google Cloud Deployment Manager YAML spec files. It also creates a new spec file for logs-based metrics, creating, for now, a single logs-based metric for platform cluster kernel logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/38)
<!-- Reviewable:end -->
