### PR TITLE
Fix specMatch & add extra logging

### DIFF
--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -26,6 +26,7 @@ steps:
   args: [
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
+             '-logx.debug=true',
              '-time=02:30:00',
              '-maxFileAge=36h',
              '-include=ndt',

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -26,7 +26,6 @@ steps:
   args: [
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
-             '-logx.debug=true',
              '-time=02:30:00',
              '-maxFileAge=36h',
              '-include=ndt',

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -58,6 +58,7 @@ func (c *Command) find(ctx context.Context) (*storagetransfer.TransferJob, error
 func (c *Command) Sync(ctx context.Context) (*storagetransfer.TransferJob, error) {
 	found, err := c.find(ctx)
 	if err != errNotFound && err != nil {
+		logx.Debug.Println("After find:", err)
 		return nil, err
 	}
 	if found != nil {
@@ -75,6 +76,7 @@ func (c *Command) Sync(ctx context.Context) (*storagetransfer.TransferJob, error
 		}
 	}
 	// Create new job matching the preferred spec.
+	logx.Debug.Println("Creating new job!")
 	return c.Create(ctx)
 }
 

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -116,12 +116,12 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 			return false
 		}
 	} else if !includesEqual(cond.IncludePrefixes, c.Prefixes) ||
-		fmt.Sprintf("%0.fs", c.MaxFileAge.Seconds()) != cond.MaxTimeElapsedSinceLastModification ||
-		fmt.Sprintf("%0.fs", c.MinFileAge.Seconds()) != cond.MinTimeElapsedSinceLastModification {
+		c.MaxFileAge.String() != cond.MaxTimeElapsedSinceLastModification ||
+		c.MinFileAge.String() != cond.MinTimeElapsedSinceLastModification {
 		logx.Debug.Println("spec includes not equal",
 			cond.IncludePrefixes, c.Prefixes,
-			cond.MaxTimeElapsedSinceLastModification, c.MaxFileAge,
-			cond.MinTimeElapsedSinceLastModification, c.MinFileAge)
+			cond.MaxTimeElapsedSinceLastModification, c.MaxFileAge.String(),
+			cond.MinTimeElapsedSinceLastModification, c.MinFileAge.String())
 		return false
 	}
 

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -34,11 +34,14 @@ func (c *Command) find(ctx context.Context) (*storagetransfer.TransferJob, error
 				continue
 			}
 			logx.Debug.Print(pretty.Sprint(job))
+			logx.Debug.Println("desc:", desc)
+			logx.Debug.Println("description:", job.Description)
 			if desc == job.Description {
 				// Sync depends on the convention for storage transfer job management that
 				// each job has a unique description, so the first
 				// matching job should be the only matching job.
 				found = job
+				logx.Debug.Println("Found job")
 				return nil
 			}
 		}

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -3,6 +3,7 @@ package stctl
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/logx"
@@ -116,8 +117,8 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 			return false
 		}
 	} else if !includesEqual(cond.IncludePrefixes, c.Prefixes) ||
-		c.MaxFileAge.String() != cond.MaxTimeElapsedSinceLastModification ||
-		c.MinFileAge.String() != cond.MinTimeElapsedSinceLastModification {
+		!compareTimes(c.MaxFileAge, cond.MaxTimeElapsedSinceLastModification) ||
+		!compareTimes(c.MinFileAge, cond.MinTimeElapsedSinceLastModification) {
 		logx.Debug.Println("spec includes not equal",
 			cond.IncludePrefixes, c.Prefixes,
 			cond.MaxTimeElapsedSinceLastModification, c.MaxFileAge.String(),
@@ -132,4 +133,10 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 	}
 
 	return true
+}
+
+func compareTimes(age time.Duration, elapsed string) bool {
+	// Accept that an error parsing correctly means zero seconds.
+	d, _ := time.ParseDuration(elapsed)
+	return age == d
 }

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -113,8 +113,8 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 			return false
 		}
 	} else if !includesEqual(cond.IncludePrefixes, c.Prefixes) ||
-		!compareTimes(c.MaxFileAge, cond.MaxTimeElapsedSinceLastModification) ||
-		!compareTimes(c.MinFileAge, cond.MinTimeElapsedSinceLastModification) {
+		!durationsMatch(c.MaxFileAge, cond.MaxTimeElapsedSinceLastModification) ||
+		!durationsMatch(c.MinFileAge, cond.MinTimeElapsedSinceLastModification) {
 		logx.Debug.Println("spec: conditions not equal",
 			cond.IncludePrefixes, c.Prefixes,
 			cond.MaxTimeElapsedSinceLastModification, c.MaxFileAge.String(),
@@ -132,7 +132,7 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 }
 
 // Convert the string based times from the ST API to numbers to make comparisons trivial.
-func compareTimes(age time.Duration, elapsed string) bool {
+func durationsMatch(age time.Duration, elapsed string) bool {
 	// Accept that an error parsing correctly means zero seconds.
 	d, _ := time.ParseDuration(elapsed)
 	return age == d

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -106,21 +106,28 @@ func includesEqual(configured []string, desired []string) bool {
 func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 	if job.Schedule.StartTimeOfDay == nil ||
 		!timesEqual(job.Schedule.StartTimeOfDay, c.StartTime) {
+		logx.Debug.Println("spec times not equal", job.Schedule, c.StartTime)
 		return false
 	}
 	cond := job.TransferSpec.ObjectConditions
 	if cond == nil {
 		if len(c.Prefixes) > 0 || c.MaxFileAge > 0 || c.MinFileAge > 0 {
+			logx.Debug.Println("spec conditions not equal", cond, c.Prefixes, c.MaxFileAge, c.MinFileAge)
 			return false
 		}
 	} else if !includesEqual(cond.IncludePrefixes, c.Prefixes) ||
 		fmt.Sprintf("%0.fs", c.MaxFileAge.Seconds()) != cond.MaxTimeElapsedSinceLastModification ||
 		fmt.Sprintf("%0.fs", c.MinFileAge.Seconds()) != cond.MinTimeElapsedSinceLastModification {
+		logx.Debug.Println("spec includes not equal",
+			cond.IncludePrefixes, c.Prefixes,
+			cond.MaxTimeElapsedSinceLastModification, c.MaxFileAge,
+			cond.MinTimeElapsedSinceLastModification, c.MinFileAge)
 		return false
 	}
 
 	jobDeleteOption := job.TransferSpec.TransferOptions != nil && job.TransferSpec.TransferOptions.DeleteObjectsFromSourceAfterTransfer
 	if c.DeleteAfterTransfer != jobDeleteOption {
+		logx.Debug.Println("spec delete after transfer not equal", jobDeleteOption, c.DeleteAfterTransfer)
 		return false
 	}
 


### PR DESCRIPTION
This change fixes a bug that resulted in unnecessary recreation of jobs due to poor matching of the transfer condition times.

This change also adds additional debug logging for error cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/41)
<!-- Reviewable:end -->
