### PR TITLE
Add cbctl to automate creation of cloud build triggers in GCP

### DIFF
--- a/cmd/cbctl/main.go
+++ b/cmd/cbctl/main.go
@@ -137,7 +137,7 @@ func main() {
 	switch op {
 	case "list":
 		log.Println("Listing build triggers")
-		err := cmd.List(ctx, func(tr *cloudbuild.ListBuildTriggersResponse) error {
+		err := cmd.List(ctx, project, func(tr *cloudbuild.ListBuildTriggersResponse) error {
 			for _, t := range tr.Triggers {
 				pretty.Print(t)
 			}

--- a/cmd/cbctl/main.go
+++ b/cmd/cbctl/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 gcp-config Authors.
+// Copyright © 2021 gcp-config Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cbctl/main.go
+++ b/cmd/cbctl/main.go
@@ -1,0 +1,183 @@
+// Copyright © 2019 gcp-config Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/m-lab/gcp-config/internal/cbctl"
+
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
+	"github.com/stephen-soltesz/pretty"
+
+	"google.golang.org/api/cloudbuild/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+var (
+	org      string
+	repo     string
+	project  string
+	filename string
+	branch   string
+	tag      string
+	projects flagx.StringArray
+)
+
+func init() {
+	flag.StringVar(&org, "org", "m-lab", "Github organization containing repos")
+	flag.StringVar(&repo, "repo", "", "Github source repo")
+	flag.StringVar(&project, "project", "mlab-sandbox", "GCP project name")
+	flag.Var(&projects, "projects", "A sequence of GCP project names")
+	flag.StringVar(&filename, "filename", "cloudbuild.yaml", "Name of the cloudbuild configuration to use")
+	flag.StringVar(&branch, "branch", "", "Pattern to match branches for this trigger")
+	flag.StringVar(&tag, "tag", "", "Pattern to match tags for this trigger")
+}
+
+func mustArg(n int) string {
+	args := flag.Args()
+	if len(args)-1 < n {
+		flag.Usage()
+		os.Exit(1)
+	}
+	return args[n]
+}
+
+func formatDesc(tag, branch string) string {
+	var d string
+	switch {
+	case tag != "":
+		d = "Tag matching " + tag
+	case branch != "":
+		d = "Push to branch matching " + branch
+	default:
+		panic("not yet supported")
+	}
+	return d
+}
+
+func newPushTrigger(org, repo, tag, branch, filename string) *cloudbuild.BuildTrigger {
+	bt := &cloudbuild.BuildTrigger{
+		// NOTE: trigger name depends only on the repo, so multiple projects use the same name.
+		Name:        "push-" + org + "-" + repo + "-trigger",
+		Description: formatDesc(tag, branch),
+		Filename:    filename,
+		Github: &cloudbuild.GitHubEventsConfig{
+			Name:  repo,
+			Owner: org,
+			Push: &cloudbuild.PushFilter{
+				Tag:    tag,
+				Branch: branch,
+			},
+		},
+	}
+	return bt
+}
+
+func newPRTrigger(org, repo, branch, filename string) *cloudbuild.BuildTrigger {
+	bt := &cloudbuild.BuildTrigger{
+		Name:        "pr-" + org + "-" + repo + "-trigger",
+		Description: formatDesc("", branch),
+		Filename:    filename,
+		Github: &cloudbuild.GitHubEventsConfig{
+			Name:  repo,
+			Owner: org,
+			PullRequest: &cloudbuild.PullRequestFilter{
+				Branch: branch,
+			},
+		},
+	}
+	return bt
+}
+
+func ignore409(err error) error {
+	if e, ok := err.(*googleapi.Error); ok {
+		if e.Code == http.StatusConflict {
+			return nil
+		}
+		pretty.Print(e)
+	}
+	return err
+}
+
+func main() {
+	flag.Parse()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	s, err := cloudbuild.NewService(ctx, option.WithScopes(cloudbuild.CloudPlatformScope))
+	rtx.Must(err, "Failed to create cb service")
+
+	cmd := cbctl.NewTrigger(s)
+
+	// Assert that only one of tag or branch are not empty.
+	if tag != "" && branch != "" {
+		log.Println("Specify only one of -branch or -tag")
+		os.Exit(1)
+	}
+
+	op := mustArg(0)
+	switch op {
+	case "list":
+		log.Println("Listing build triggers")
+		err := cmd.List(ctx, func(tr *cloudbuild.ListBuildTriggersResponse) error {
+			for _, t := range tr.Triggers {
+				pretty.Print(t)
+			}
+			return nil
+		})
+		rtx.Must(err, "Failed to list triggers")
+
+	case "trigger":
+		log.Println("TODO: implement trigger")
+
+	case "create":
+		log.Println("Creating single trigger")
+		bt := newPushTrigger(org, repo, tag, branch, filename)
+		t, err := cmd.Create(ctx, project, bt)
+		rtx.Must(err, "Failed to create trigger")
+		pretty.Print(t)
+
+	case "create-projects":
+		log.Println("Creating standard triggers across several projects")
+
+		opts := []struct {
+			tag    string
+			branch string
+		}{
+			{branch: "sandbox-.*"},
+			{branch: "master"},
+			{tag: "v([0-9.]+)+"},
+		}
+		for i, opt := range opts {
+			if len(projects) < len(opts) {
+				log.Printf("Skipping: %#v", opt)
+				continue
+			}
+			bt := newPushTrigger(org, repo, opt.tag, opt.branch, filename)
+			t, err := cmd.Create(ctx, projects[i], bt)
+			rtx.Must(ignore409(err), "Failed to create trigger")
+			pretty.Print(t)
+		}
+
+	default:
+		flag.Usage()
+	}
+}

--- a/internal/cbctl/trigger.go
+++ b/internal/cbctl/trigger.go
@@ -1,0 +1,48 @@
+// Copyright © 2019 gcp-config Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cloudbuild wraps the upstream cloudbuild package in a simplified
+// interface. All code MUST be correct by inspection.
+package cbctl
+
+import (
+	"context"
+
+	"google.golang.org/api/cloudbuild/v1"
+)
+
+// Trigger wraps the cloudbuild API into a simple interface.
+type Trigger struct {
+	service *cloudbuild.Service
+}
+
+// NewTrigger creates a new Trigger instance.
+func NewTrigger(s *cloudbuild.Service) *Trigger {
+	return &Trigger{
+		service: s,
+	}
+}
+
+func (t *Trigger) Run(ctx context.Context, project string, triggerId string, src *cloudbuild.RepoSource) (*cloudbuild.Operation, error) {
+	return t.service.Projects.Triggers.Run(project, triggerId, src).Context(ctx).Do()
+}
+
+func (t *Trigger) Create(ctx context.Context, project string, bt *cloudbuild.BuildTrigger) (*cloudbuild.BuildTrigger, error) {
+	return t.service.Projects.Triggers.Create(project, bt).Context(ctx).Do()
+}
+
+func (t *Trigger) List(ctx context.Context, project string, visit func(tr *cloudbuild.ListBuildTriggersResponse) error) error {
+	c := t.service.Projects.Triggers.List(project)
+	return c.Pages(ctx, visit)
+}

--- a/internal/cbctl/trigger.go
+++ b/internal/cbctl/trigger.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 gcp-config Authors.
+// Copyright © 2021 gcp-config Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change adds a new command line tool to gcp-config: `cbctl`. This tool should help automate the setup of our standard multi-stage development and deployment cycles to sandbox, staging, and mlab-oti.

This tool is useful enough that I am submitting it for review with out unit tests. However, this should not be taken as indication that the tool need not have them, only that it does not have them yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/42)
<!-- Reviewable:end -->
