### PR TITLE
Builds custom Docker image for siteinfo repository builds

### DIFF
--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,8 +1,3 @@
 FROM golang:1.15
-# CGO_ENABLED=0 creates a statically linked binary.
-# The -ldflags drop another 2.5MB from the binary size.
-# -w    Omit the DWARF symbol table.
-# -s    Omit the symbol table and debug information.
-RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_admin
-RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/gcp-config/cmd/cbctl
-
+RUN go get github.com/m-lab/epoxy/cmd/epoxy_admin
+RUN go get github.com/m-lab/gcp-config/cmd/cbctl

--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,16 +1,4 @@
-FROM ubuntu:20.04
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update --fix-missing
-RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
-    lzma-dev liblzma-dev autopoint pkg-config libtool autotools-dev upx-ucl \
-    isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
-    strace cpio squashfs-tools curl lsb-release gawk rsync \
-    mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
-    linux-source golang xorriso jq
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
-ENV GOROOT /usr/lib/go
-RUN mkdir /go
-ENV GOPATH /go
+FROM golang:1.15
 # CGO_ENABLED=0 creates a statically linked binary.
 # The -ldflags drop another 2.5MB from the binary size.
 # -w    Omit the DWARF symbol table.

--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,0 +1,20 @@
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update --fix-missing
+RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
+    lzma-dev liblzma-dev autopoint pkg-config libtool autotools-dev upx-ucl \
+    isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
+    strace cpio squashfs-tools curl lsb-release gawk rsync \
+    mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
+    linux-source golang xorriso jq
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
+ENV GOROOT /usr/lib/go
+RUN mkdir /go
+ENV GOPATH /go
+# CGO_ENABLED=0 creates a statically linked binary.
+# The -ldflags drop another 2.5MB from the binary size.
+# -w    Omit the DWARF symbol table.
+# -s    Omit the symbol table and debug information.
+RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_admin
+RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/gcp-config/cmd/cbctl
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,3 +41,4 @@ images:
 - 'gcr.io/$PROJECT_ID/golang-cbif'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'
 - 'gcr.io/$PROJECT_ID/epoxy-images'
+- 'gcr.io/$PROJECT_ID/siteinfo'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,6 @@
+# Default total build time is 10m, which isn't always enough.
+timeout: 1800s
+
 ############################################################################
 # Create project-specific customized builder images.
 ############################################################################

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,6 +26,14 @@ steps:
     '--file=Dockerfile.epoxy-images', '.'
   ]
 
+# Build siteinfo image
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build',
+    '--tag=gcr.io/$PROJECT_ID/siteinfo',
+    '--file=Dockerfile.siteinfo', '.'
+  ]
+
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'


### PR DESCRIPTION
A number of things currently hinge on changes to siteinfo. For example, currently, when a new site is added to siteinfo, an operator must manually go and trigger a build on the epoxy-images repository to cause boot images to be built for the new site. Same thing for adding ePoxy GCD entities when a new site is added. Same thing for the switch-config repository. This PR is a first step in automating those manual processes. It creates a custom Docker image for the siteinfo repository which contains the `epoxy_admin` and `cbctl` utilities. The former for creating ePoxy GCD entities for a site, the latter for triggering builds of the epoxy-images and switch-config repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/45)
<!-- Reviewable:end -->
