### PR TITLE
Adds flagx.ArgsFromEnvWithLog(<flagset>, false) to main()

### DIFF
--- a/cmd/cbctl/main.go
+++ b/cmd/cbctl/main.go
@@ -203,8 +203,11 @@ func getBuildTargetRef(ctx context.Context, gh *github.Client, project string) s
 
 func main() {
 	flag.Parse()
+	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, false), "Could not parse env args")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
 	s, err := cloudbuild.NewService(ctx, option.WithScopes(cloudbuild.CloudPlatformScope))
 	rtx.Must(err, "Failed to create cb service")
 


### PR DESCRIPTION
This feature will be used to pass a Github token to `cbctl`'s `-github_token` flag through the environment, not printing it in the Cloud Build logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/48)
<!-- Reviewable:end -->
