### PR TITLE
Updates Go to v1.16.x in epoxy-images build image

### DIFF
--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -6,7 +6,7 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
     strace cpio squashfs-tools curl lsb-release gawk rsync \
     mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
-    linux-source golang xorriso jq
+    linux-source golang-1.16 xorriso jq
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
 ENV GOROOT /usr/lib/go
 RUN mkdir /go
@@ -15,5 +15,5 @@ ENV GOPATH /go
 # The -ldflags drop another 2.5MB from the binary size.
 # -w    Omit the DWARF symbol table.
 # -s    Omit the symbol table and debug information.
-RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client
+RUN CGO_ENABLED=0 GO111MODULE=auto go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client
 

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -10,7 +10,7 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
 # Adds go-1.16 binary to a known location in $PATH
 RUN update-alternatives --install /usr/local/bin/go go /usr/lib/go-1.16/bin/go 10
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
-ENV GOROOT /usr/lib/go
+ENV GOROOT /usr/lib/go-1.16
 RUN mkdir /go
 ENV GOPATH /go
 # CGO_ENABLED=0 creates a statically linked binary.

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -7,6 +7,8 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     strace cpio squashfs-tools curl lsb-release gawk rsync \
     mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
     linux-source golang-1.16 xorriso jq
+# Adds go-1.16 binary to a known location in $PATH
+RUN update-alternatives --install /usr/local/bin/go go /usr/lib/go-1.16/bin/go 10
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
 ENV GOROOT /usr/lib/go
 RUN mkdir /go


### PR DESCRIPTION
This is in preparation for leveraging Go modules (without special env variables) to install versioned CNI plugins inside of stage3 Ubuntu images.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/50)
<!-- Reviewable:end -->
