### PR TITLE
Updates Go to 1.16 in Dockerfile.golang

### DIFF
--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 ADD . /go/src/github.com/m-lab/gcp-config
 RUN apt-get update && apt-get install -y git
 RUN go get -v github.com/m-lab/gcp-config/cmd/cbif


### PR DESCRIPTION
Builds of Locate are failing because this build environment is still using Go 1.14. Moving to 1.16 fixes the build, and I will also introduce Go modules to Locate.

There are [maybe six other repositories](https://github.com/search?q=org%3Am-lab+golang-cbif&type=code) using the image built by this Dockerfile. It's not impossible that this change could break builds in those repos. But my thinking is that we have to keep moving into the present and future, and if this change does for some odd reason break some other build that requires this image, then the right thing to do will be to make updates to that repo to support at least version 1.16 of Go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/51)
<!-- Reviewable:end -->
