### PR TITLE
Add legacy scamper copy for host and neubot

### DIFF
--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -84,7 +84,15 @@ for year in 2019 2020 ; do
 done
 
 for year in 2019 2020 2021 ; do
-  safe_rsync gs://${archive}/ndt/traceroute/${year} gs://${archive}/ndt/scamper1/${year}/
+  safe_rsync gs://${archive}/ndt/traceroute/${year}/ gs://${archive}/ndt/scamper1/${year}/
+done
+
+for year in 2019 2020 2021 ; do
+  safe_rsync gs://${archive}/host/traceroute/${year}/ gs://${archive}/host/scamper1/${year}/
+done
+
+for year in 2019 2020 2021 ; do
+  safe_rsync gs://${archive}/neubot/traceroute/${year}/ gs://${archive}/neubot/scamper1/${year}/
 done
 
 # Delete exits to proceed to remove legacy folders.

--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -83,16 +83,11 @@ for year in 2019 2020 ; do
   safe_rsync gs://${archive}/ndt/ndt7/download/${year}/ gs://${archive}/ndt/ndt7/${year}/
 done
 
+# ndt/host/neubot traceroute.
 for year in 2019 2020 2021 ; do
   safe_rsync gs://${archive}/ndt/traceroute/${year}/ gs://${archive}/ndt/scamper1/${year}/
-done
-
-for year in 2019 2020 2021 ; do
   safe_rsync gs://${archive}/host/traceroute/${year}/ gs://${archive}/host/scamper1/${year}/
-done
-
-for year in 2019 2020 2021 ; do
-  safe_rsync gs://${archive}/neubot/traceroute/${year}/ gs://${archive}/neubot/scamper1/${year}/
+  safe_rsync gs://${archive}/neubot/traceroute/${year}/ gs://${archive}/neubot/scamper1/${year}
 done
 
 # Delete exits to proceed to remove legacy folders.

--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -87,7 +87,7 @@ done
 for year in 2019 2020 2021 ; do
   safe_rsync gs://${archive}/ndt/traceroute/${year}/ gs://${archive}/ndt/scamper1/${year}/
   safe_rsync gs://${archive}/host/traceroute/${year}/ gs://${archive}/host/scamper1/${year}/
-  safe_rsync gs://${archive}/neubot/traceroute/${year}/ gs://${archive}/neubot/scamper1/${year}
+  safe_rsync gs://${archive}/neubot/traceroute/${year}/ gs://${archive}/neubot/scamper1/${year}/
 done
 
 # Delete exits to proceed to remove legacy folders.


### PR DESCRIPTION
Copy legacy scamper data for the `host` and `neubot` experiments.

Also, added forward slash to the `rsync` command for `ndt` for consistency with the original commands.

Data copied in sandbox:
**host**
https://pantheon.corp.google.com/storage/browser/archive-mlab-sandbox/host/scamper1?project=mlab-sandbox&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false

**neubot**
https://pantheon.corp.google.com/storage/browser/archive-mlab-sandbox/neubot/scamper1?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=mlab-sandbox&prefix=&forceOnObjectsSortingFiltering=false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/53)
<!-- Reviewable:end -->
