### PR TITLE
Remove legacy scamper files in GCS

### DIFF
--- a/adhoc/normalize_gcs_archive.sh
+++ b/adhoc/normalize_gcs_archive.sh
@@ -123,3 +123,10 @@ for year in 2019 2020 ; do
   time gsutil -m rm -r gs://${archive}/ndt/ndt7/upload/${year}/
   time gsutil -m rm -r gs://${archive}/ndt/ndt7/download/${year}/
 done
+
+# ndt/host/neubot traceroute.
+for year in 2019 2020 2021 ; do
+  time gsutil -m rm -r gs://${archive}/ndt/traceroute/${year}/
+  time gsutil -m rm -r gs://${archive}/host/traceroute/${year}/
+  time gsutil -m rm -r gs://${archive}/neubot/traceroute/${year}/
+done


### PR DESCRIPTION
This was run in sandbox.

The only folder that remained is [archive-mlab-sandbox/ndt/traceroute/](https://pantheon.corp.google.com/storage/browser/archive-mlab-sandbox/ndt/traceroute;tab=objects?project=mlab-sandbox&prefix=&forceOnObjectsSortingFiltering=false) because it has two files that did not belong to any of the year sub-folders. I checked the other ndt/host/neubot buckets in staging and oti and they don't have any straggler files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/56)
<!-- Reviewable:end -->
