### PR TITLE
Update to golang 1.18, with tagged builds

### DIFF
--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,5 +1,5 @@
-FROM golang:1.16
+FROM golang:1.18
 ADD . /go/src/github.com/m-lab/gcp-config
 RUN apt-get update && apt-get install -y git
-RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -1,12 +1,12 @@
 # Build cbif for entrypoint.
-FROM golang:1.14 AS cbif-go-builder
+FROM golang:1.18 AS cbif-go-builder
 ADD . /go/src/github.com/m-lab/gcp-config
-RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 
 # Build Go version of jsonnet.
-FROM golang:1.14 AS jsonnet-go-builder
+FROM golang:1.18 AS jsonnet-go-builder
 RUN apt-get install -y git
-RUN go get -v github.com/google/go-jsonnet/cmd/jsonnet
+RUN go install -v github.com/google/go-jsonnet/cmd/jsonnet@latest
 
 # Build CPP version of jsonnet.
 # NOTE: Use the same base image as the final image so that shared libraries

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,7 @@
 # Default total build time is 10m, which isn't always enough.
 timeout: 1800s
+options:
+  machineType: 'N1_HIGHCPU_8'
 
 ############################################################################
 # Create project-specific customized builder images.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
 # Build golang-cbif container. Useful golang builds and tests.
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif',
+    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.18',
     '--file=Dockerfile.golang', '.'
   ]
 
@@ -17,9 +17,10 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif',
+    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18',
     '--file=Dockerfile.jsonnet', '.'
   ]
+  waitFor: ['-']
 
 # Build epoxy-images image
 - name: gcr.io/cloud-builders/docker
@@ -28,6 +29,7 @@ steps:
     '--tag=gcr.io/$PROJECT_ID/epoxy-images',
     '--file=Dockerfile.epoxy-images', '.'
   ]
+  waitFor: ['-']
 
 # Build siteinfo-cbif image. Used by siteinto repository builds.
 - name: gcr.io/cloud-builders/docker
@@ -36,6 +38,7 @@ steps:
     '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif',
     '--file=Dockerfile.siteinfo', '.'
   ]
+  waitFor: ['-']
 
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif:1.18'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,8 @@
 # Default total build time is 10m, which isn't always enough.
 timeout: 1800s
+
 options:
+  # Allow images to build more quickly.
   machineType: 'N1_HIGHCPU_8'
 
 ############################################################################

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
   ]
 
 images:
-- 'gcr.io/$PROJECT_ID/golang-cbif'
+- 'gcr.io/$PROJECT_ID/golang-cbif:1.18'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'
 - 'gcr.io/$PROJECT_ID/epoxy-images'
 - 'gcr.io/$PROJECT_ID/siteinfo-cbif'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,6 +39,6 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif:1.18'
-- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif'
+- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18'
 - 'gcr.io/$PROJECT_ID/epoxy-images'
 - 'gcr.io/$PROJECT_ID/siteinfo-cbif'


### PR DESCRIPTION
This change updates the `golang-cbif:1.18` and `gcloud-jsonnet-cbif:1.18` images to use go1.18 and explicitly tags the image version based on the Go version (i.e. 1.18). Previously, our builds (and users of these images) unconditionally used the 'latest' tag. Due to the differences between go1.18 and earlier versions, this change introduces explicit image version tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/58)
<!-- Reviewable:end -->
