### PR TITLE
Delete after transfer from archive to archive

### DIFF
--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -65,6 +65,7 @@ steps:
              '-gcs.target=archive-measurement-lab',
              '-time=06:30:00',
              '-maxFileAge=27h',
+             '-deleteAfterTransfer=true',
              'sync'
   ]
 
@@ -104,6 +105,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=18:30:00',
+             '-deleteAfterTransfer=true',
              '-maxFileAge=192h',  # 8 days
              'sync'
   ]


### PR DESCRIPTION
This change enables `deleteAfterTransfer` for the archive-mlab-oti to archive-measurement-lab daily transfers. Since mlab-oti is the production project (hence most data) and this data's final destination is archive-measurement-lab (unlike archive-mlab-sandbox and archive-mlab-staging which are terminal locations), and our data pipeline sources data from archive-measurement-lab, we can safely enable `deleteAfterTransfer` for archive-mlab-oti.

Part of:
* https://github.com/m-lab/dev-tracker/issues/729

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/60)
<!-- Reviewable:end -->
