### PR TITLE
Bounds regexp for matching branch

### DIFF
--- a/cmd/cbctl/main.go
+++ b/cmd/cbctl/main.go
@@ -57,12 +57,14 @@ DESCRIPTION:
   rules across multiple projects. Among other things, cbctl automates creating
   "sandbox", "staging", and "production" build triggers for GitHub repos.
 
-  NOTE: before this utility will work, you must [manually connect the Github
-  repository to Cloud
-  Build](https://cloud.google.com/build/docs/automating-builds/create-manage-triggers#connect_repo)
-  from the Cloud Build interface. The process of connecting a repository will
-  ask you if you want to create a trigger. **DO NOT** create a new trigger in
-  that workflow, or you will have duplicate triggers. That
+  NOTE: before this utility will work, you must manually connect the Github
+  repository to Cloud Build:
+
+  https://cloud.google.com/build/docs/automating-builds/create-manage-triggers#connect_repo
+
+  The process of connecting a repository will ask you if you want to create a
+  trigger. **DO NOT** create a new trigger in that workflow, or you will have
+  duplicate triggers.
 
   Basic usage:
 


### PR DESCRIPTION
The regular expressions for matching branch and tag names was unbounded,
possibly causing unintended matching. Additionally, this commit removes
the -projects flag and hardcodes the 3 M-Lab projects. It also renamed
the operation "create-projects" to "create-mlab-projects".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/62)
<!-- Reviewable:end -->
