### PR TITLE
Update to use go1.18 and generate versioned images

### DIFF
--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -28,6 +28,5 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 # The -ldflags drop another 2.5MB from the binary size.
 # -w    Omit the DWARF symbol table.
 # -s    Omit the symbol table and debug information.
-#RUN go install github.com/m-lab/epoxy/cmd/epoxy_client@latest
-RUN CGO_ENABLED=0 GO111MODULE=auto go install -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client@latest
+RUN CGO_ENABLED=0 go install -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client@latest
 

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -6,16 +6,28 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
     strace cpio squashfs-tools curl lsb-release gawk rsync \
     mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
-    linux-source golang-1.16 xorriso jq
-# Adds go-1.16 binary to a known location in $PATH
-RUN update-alternatives --install /usr/local/bin/go go /usr/lib/go-1.16/bin/go 10
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go/bin
-ENV GOROOT /usr/lib/go-1.16
-RUN mkdir /go
+    linux-source xorriso jq
+
+# Fetch recent go version.
+# NOTE: As of 2022-08-31, golang-1.18 was not an available package in ubuntu:20.04
+ENV GOLANG_VERSION 1.18.5
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+    && tar -C /usr/local/ -xzf golang.tar.gz \
+    && rm golang.tar.gz
+
 ENV GOPATH /go
+RUN mkdir /go
+ENV GOROOT /usr/local/go/
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 # CGO_ENABLED=0 creates a statically linked binary.
 # The -ldflags drop another 2.5MB from the binary size.
 # -w    Omit the DWARF symbol table.
 # -s    Omit the symbol table and debug information.
-RUN CGO_ENABLED=0 GO111MODULE=auto go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client
+#RUN go install github.com/m-lab/epoxy/cmd/epoxy_client@latest
+RUN CGO_ENABLED=0 GO111MODULE=auto go install -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client@latest
 

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -28,5 +28,5 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 # The -ldflags drop another 2.5MB from the binary size.
 # -w    Omit the DWARF symbol table.
 # -s    Omit the symbol table and debug information.
-RUN CGO_ENABLED=0 go install -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client@latest
+RUN CGO_ENABLED=0 go install -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client@v1.2.4
 

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,5 +1,4 @@
 FROM golang:1.18
 ADD . /go/src/github.com/m-lab/gcp-config
-RUN apt-get update && apt-get install -y git
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,5 +1,5 @@
-FROM golang:1.16
-RUN go get github.com/m-lab/epoxy/cmd/epoxy_admin
-RUN go get github.com/m-lab/gcp-config/cmd/cbctl
-RUN go get github.com/m-lab/gcp-config/cmd/cbif
+FROM golang:1.18
+RUN go install github.com/m-lab/epoxy/cmd/epoxy_admin@latest
+RUN go install github.com/m-lab/gcp-config/cmd/cbctl@latest
+RUN go install github.com/m-lab/gcp-config/cmd/cbif@latest
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,5 +1,5 @@
 FROM golang:1.18
-RUN go install github.com/m-lab/epoxy/cmd/epoxy_admin@latest
-RUN go install github.com/m-lab/gcp-config/cmd/cbctl@latest
-RUN go install github.com/m-lab/gcp-config/cmd/cbif@latest
+RUN go install github.com/m-lab/epoxy/cmd/epoxy_admin@v1.2.4
+RUN go install github.com/m-lab/gcp-config/cmd/cbctl@v1.3.12
+RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 ENTRYPOINT ["/go/bin/cbif"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18',
+    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.0',
     '--file=Dockerfile.jsonnet', '.'
   ]
   waitFor: ['-']
@@ -30,7 +30,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.18',
+    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.0',
     '--file=Dockerfile.epoxy-images', '.'
   ]
   waitFor: ['-']
@@ -39,13 +39,13 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.18',
+    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.0',
     '--file=Dockerfile.siteinfo', '.'
   ]
   waitFor: ['-']
 
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif:1.18'
-- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18'
-- 'gcr.io/$PROJECT_ID/epoxy-images:1.18'
-- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.18'
+- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.0'
+- 'gcr.io/$PROJECT_ID/epoxy-images:1.0'
+- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.0'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/epoxy-images',
+    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.18',
     '--file=Dockerfile.epoxy-images', '.'
   ]
   waitFor: ['-']
@@ -39,7 +39,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif',
+    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.18',
     '--file=Dockerfile.siteinfo', '.'
   ]
   waitFor: ['-']
@@ -47,5 +47,5 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif:1.18'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18'
-- 'gcr.io/$PROJECT_ID/epoxy-images'
-- 'gcr.io/$PROJECT_ID/siteinfo-cbif'
+- 'gcr.io/$PROJECT_ID/epoxy-images:1.18'
+- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.18'


### PR DESCRIPTION
This change completes the update to golang:1.18 for all Dockerfiles in this repo.

All generated images are now versioned. Previously untagged images will continue to work, but dependencies (e.g. siteinfo) should be migrated to the latest tagged version for consistency.

Part of:
* https://github.com/m-lab/dev-tracker/issues/735

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/63)
<!-- Reviewable:end -->
