### PR TITLE
Adds config files for the Slack Cloud Build notifier

### DIFF
--- a/cloud-build-notifiers/README.md
+++ b/cloud-build-notifiers/README.md
@@ -1,8 +1,10 @@
 ## Cloud Build notifiers
 
-The files in this directory are used to configure Cloud Build notifiers.
-Currently, the only notifier enabled is Slack. See these documents for more
-infomation on how the Slack notifier was enabled in each project.
+The files in this directory are used to configure Cloud Build notifiers. They
+are stored in each project in a GCS bucket named like
+`<project>-notifiers-config`.  Currently, the only notifier enabled is Slack.
+See these documents for more infomation on how the Slack notifier was enabled
+in each project.
 
 * https://cloud.google.com/build/docs/configuring-notifications/configure-slack
 * https://cloud.google.com/build/docs/configuring-notifications/automate

--- a/cloud-build-notifiers/README.md
+++ b/cloud-build-notifiers/README.md
@@ -1,0 +1,26 @@
+## Cloud Build notifiers
+
+The files in this directory are used to configure Cloud Build notifiers.
+Currently, the only notifier enabled is Slack. See these documents for more
+infomation on how the Slack notifier was enabled in each project.
+
+* https://cloud.google.com/build/docs/configuring-notifications/configure-slack
+* https://cloud.google.com/build/docs/configuring-notifications/automate
+
+There are two configuration files for the Slack notifier in this repo:
+
+* slack-configuration.yaml
+
+This is the configuration file passed to the Slack Cloud Build notifier, which
+is a container image that gets launched by Cloud Run when it receives a Pub/Sub
+push notification that a Cloud Build failed. The file contains two
+`{{PROJECT}}` template variables which need to be substituted before using.
+
+* slack-message-template.json
+
+This is the Slack message template. It uses the [Slack Block
+Kit](https://api.slack.com/block-kit) for generating pretty Slack messages. Of
+note is that it does not contain the typical `blocks: []` field that the Block Kit
+generally wants to see defined in the JSON. Instead, the content should only be
+the array that is assigned to `blocks:`.
+

--- a/cloud-build-notifiers/slack-configuration.yaml
+++ b/cloud-build-notifiers/slack-configuration.yaml
@@ -1,0 +1,19 @@
+apiVersion: cloud-build-notifiers/v1
+kind: SlackNotifier
+metadata:
+  name: slack-notifier
+spec:
+  notification:
+    filter: build.status == Build.Status.FAILURE
+    delivery:
+      webhookUrl:
+        secretRef: webhook-url
+    template:
+      type: golang
+      uri: gs://{{PROJECT}}-notifiers-config/slack-message-template.json
+    params:
+      buildStatus: $(build.status)
+  secrets:
+  - name: webhook-url
+    value: projects/{{PROJECT}}/secrets/cloud-build-slack-webhook-url/versions/latest
+

--- a/cloud-build-notifiers/slack-message-template.json
+++ b/cloud-build-notifiers/slack-message-template.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "A Cloud Build failed for repo *{{.Build.Substitutions.REPO_NAME}}*. View <{{.Build.LogUrl}}|the Build logs> to see why."
+    }
+  }
+]
+


### PR DESCRIPTION
These config files were used to enable [Slack Cloud Build notifications](https://cloud.google.com/build/docs/configuring-notifications/automate) in each project. I'm adding them to this repository for lack of a better place to put them, along with a brief bit of documentation on how this was done for each project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/65)
<!-- Reviewable:end -->
