### PR TITLE
Install Hashicorp Packer into epoxy-images image

### DIFF
--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -30,3 +30,9 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 # -s    Omit the symbol table and debug information.
 RUN CGO_ENABLED=0 go install -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client@v1.2.4
 
+# Install Hashicorp Packer
+ENV PACKER_VERSION 1.8.4
+RUN curl --location --remote-name "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" \
+    && unzip "packer_${PACKER_VERSION}_linux_amd64.zip" -d /usr/local/bin \
+    && rm "packer_${PACKER_VERSION}_linux_amd64.zip"
+


### PR DESCRIPTION
This is a a setup step which will enable building custom cloud images using Hashicorp Packer in epoxy-images builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/67)
<!-- Reviewable:end -->
