### PR TITLE
Update golang version to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 ADD . /go/src/github.com/m-lab/gcp-config
 WORKDIR /go/src/github.com/m-lab/gcp-config/

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -9,10 +9,10 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     linux-source xorriso jq
 
 # Fetch recent go version.
-# NOTE: As of 2022-08-31, golang-1.18 was not an available package in ubuntu:20.04
-ENV GOLANG_VERSION 1.18.5
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2
+# NOTE: As of 2023-03-20, golang-1.20 was not an available package in ubuntu:20.04
+ENV GOLANG_VERSION 1.20.2
+ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
     && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 ADD . /go/src/github.com/m-lab/gcp-config
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -1,10 +1,10 @@
 # Build cbif for entrypoint.
-FROM golang:1.18 AS cbif-go-builder
+FROM golang:1.20 AS cbif-go-builder
 ADD . /go/src/github.com/m-lab/gcp-config
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 
 # Build Go version of jsonnet.
-FROM golang:1.18 AS jsonnet-go-builder
+FROM golang:1.20 AS jsonnet-go-builder
 RUN apt-get install -y git
 RUN go install -v github.com/google/go-jsonnet/cmd/jsonnet@latest
 

--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 RUN go install github.com/m-lab/epoxy/cmd/epoxy_admin@v1.2.5
 RUN go install github.com/m-lab/gcp-config/cmd/cbctl@v1.3.12
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
 # Build golang-cbif container. Useful golang builds and tests.
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.18',
+    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.20',
     '--file=Dockerfile.golang', '.'
   ]
 
@@ -21,7 +21,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.0',
+    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1',
     '--file=Dockerfile.jsonnet', '.'
   ]
   waitFor: ['-']
@@ -30,7 +30,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.0',
+    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.1',
     '--file=Dockerfile.epoxy-images', '.'
   ]
   waitFor: ['-']
@@ -39,13 +39,13 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.0',
+    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.1',
     '--file=Dockerfile.siteinfo', '.'
   ]
   waitFor: ['-']
 
 images:
-- 'gcr.io/$PROJECT_ID/golang-cbif:1.18'
-- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.0'
-- 'gcr.io/$PROJECT_ID/epoxy-images:1.0'
-- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.0'
+- 'gcr.io/$PROJECT_ID/golang-cbif:1.20'
+- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1'
+- 'gcr.io/$PROJECT_ID/epoxy-images:1.1'
+- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.1'


### PR DESCRIPTION
This change updates the gcp-config image builds to use golang 1.20. The previous versions will remain in the GCR so no current dependencies will break. This change enables cloud builds that depend on go1.20.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/68)
<!-- Reviewable:end -->
