### PR TITLE
Skip nil job.Schedule

### DIFF
--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -30,7 +30,7 @@ func (c *Command) find(ctx context.Context) (*storagetransfer.TransferJob, error
 	logx.Debug.Println("Listing jobs")
 	findJob := func(resp *storagetransfer.ListTransferJobsResponse) error {
 		for _, job := range resp.TransferJobs {
-			if job.Schedule.ScheduleEndDate != nil {
+			if job.Schedule == nil || job.Schedule.ScheduleEndDate != nil {
 				// We only manage jobs without an end date.
 				continue
 			}


### PR DESCRIPTION
Through the storage transfers UI, it is possible to create a job without a `Schedule` object. If this is the case, `stctl` will segfault when trying to access an object within the `nil` Schedule object. This change checks for this case and skips it also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/69)
<!-- Reviewable:end -->
