### PR TITLE
Set up sync for dedicated autoload transfer job

### DIFF
--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -40,6 +40,11 @@ steps:
 
 # Nodes upload to the pusher-* bucket every 2 hours.
 # Configure hourly pusher to local archive transfer.
+# NOTE: the hourly setting has been set by editing the job created
+# in the web UI (because it is not supported by stctl), so this
+# declaration is not identical to what is in the corresponding GCP
+# config.
+# TODO(cristinaleon): Add hourly schedule functionality to stctl.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -34,6 +34,19 @@ steps:
              '-include=revtr',
              '-include=utilization',
              '-include=wehe',
+             '-deleteAfterTransfer=true',
+             'sync'
+  ]
+
+# Nodes upload to the pusher-* bucket every 2 hours.
+# Configure hourly pusher to local archive transfer.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
+  args: [
+    'stctl', '-gcs.source=pusher-$PROJECT_ID',
+             '-gcs.target=archive-$PROJECT_ID',
+             '-time=00:00:00',
              '-include=autoload',
              '-deleteAfterTransfer=true',
              'sync'
@@ -92,7 +105,6 @@ steps:
              '-include=revtr',
              '-include=utilization',
              '-include=wehe',
-             '-include=autoload',
              '-deleteAfterTransfer=true',
              'sync'
   ]


### PR DESCRIPTION
This PR sets up a sync for a dedicated transfer job of autoloaded data.

The job runs hourly. It only transfers data under the "autoload" prefix from the pusher bucket to the archive bucket.

https://pantheon.corp.google.com/transfer/jobs/transferJobs%2F10435470182208531695/configuration?project=mlab-sandbox

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/71)
<!-- Reviewable:end -->
