### PR TITLE
Add job to transfer autoloaded data to measurement-lab

### DIFF
--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -147,7 +147,6 @@ steps:
              'sync'
   ]
 
-
 # TODO(soltesz): once ST schedules above stabilize, bring backup transfer
 # schedule in sync. Until then, complete daily backups will be delayed by a day.
 

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -129,6 +129,24 @@ steps:
              'sync'
   ]
 
+# Hourly local archive to public archive transfer for autoloaded data.
+# NOTE: the hourly setting has been set by editing the job created
+# in the web UI (because it is not supported by stctl), so this
+# declaration is not identical to what is in the corresponding GCP
+# config.
+# TODO(cristinaleon): Add hourly schedule functionality to stctl.
+- name: gcp-config-cbif
+  env:
+  - PROJECT_IN=measurement-lab
+  args: [
+    'stctl', '-gcs.source=archive-mlab-oti',
+             '-gcs.target=archive-measurement-lab',
+             '-time=00:00:00',
+             '-include=autoload',
+             '-deleteAfterTransfer=true',
+             'sync'
+  ]
+
 
 # TODO(soltesz): once ST schedules above stabilize, bring backup transfer
 # schedule in sync. Until then, complete daily backups will be delayed by a day.


### PR DESCRIPTION
This PR adds a new job to transfer autoloaded data from "archive-mlab-oti" to "archive-measurement-lab".

The job will be edited to an hourly frequency after creation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/72)
<!-- Reviewable:end -->
