### PR TITLE
Change Go version back to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.18
+- 1.20
 
 install:
 - go get -v -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.21
+- 1.18
 
 install:
 - go get -v -t ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.20
 
 ADD . /go/src/github.com/m-lab/gcp-config
 WORKDIR /go/src/github.com/m-lab/gcp-config/

--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -9,10 +9,10 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     linux-source xorriso jq
 
 # Fetch recent go version.
-# NOTE: Starting with Go 1.21, the initial release for a release family is of the form 1.N.0.
-ENV GOLANG_VERSION 1.21.0
+# NOTE: As of 2023-03-20, golang-1.20 was not an available package in ubuntu:20.04
+ENV GOLANG_VERSION 1.20.2
 ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742
+ENV GOLANG_DOWNLOAD_SHA256 4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
     && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.20
 ADD . /go/src/github.com/m-lab/gcp-config
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.jsonnet
+++ b/Dockerfile.jsonnet
@@ -1,10 +1,10 @@
 # Build cbif for entrypoint.
-FROM golang:1.21 AS cbif-go-builder
+FROM golang:1.20 AS cbif-go-builder
 ADD . /go/src/github.com/m-lab/gcp-config
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
 
 # Build Go version of jsonnet.
-FROM golang:1.21 AS jsonnet-go-builder
+FROM golang:1.20 AS jsonnet-go-builder
 RUN apt-get install -y git
 RUN go install -v github.com/google/go-jsonnet/cmd/jsonnet@latest
 

--- a/Dockerfile.siteinfo
+++ b/Dockerfile.siteinfo
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.20
 RUN go install github.com/m-lab/epoxy/cmd/epoxy_admin@v1.2.5
 RUN go install github.com/m-lab/gcp-config/cmd/cbctl@v1.3.12
 RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
 # Build golang-cbif container. Useful golang builds and tests.
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.21',
+    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.20',
     '--file=Dockerfile.golang', '.'
   ]
 
@@ -21,7 +21,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.2',
+    '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1',
     '--file=Dockerfile.jsonnet', '.'
   ]
   waitFor: ['-']
@@ -30,7 +30,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.2',
+    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.1',
     '--file=Dockerfile.epoxy-images', '.'
   ]
   waitFor: ['-']
@@ -39,13 +39,13 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.2',
+    '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.1',
     '--file=Dockerfile.siteinfo', '.'
   ]
   waitFor: ['-']
 
 images:
-- 'gcr.io/$PROJECT_ID/golang-cbif:1.21'
-- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.2'
-- 'gcr.io/$PROJECT_ID/epoxy-images:1.2'
-- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.2'
+- 'gcr.io/$PROJECT_ID/golang-cbif:1.20'
+- 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1'
+- 'gcr.io/$PROJECT_ID/epoxy-images:1.1'
+- 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.1'

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/m-lab/gcp-config
 
-go 1.18
+go 1.20
 
 require (
-	cloud.google.com/go v0.81.0
 	github.com/go-test/deep v1.0.4
 	github.com/google/go-github/v35 v35.2.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -11,15 +10,14 @@ require (
 	github.com/stephen-soltesz/pretty v0.0.0-20181228034758-e18cda1ae6b8
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	google.golang.org/api v0.46.0
-	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a
 	gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0
 )
 
 require (
+	cloud.google.com/go v0.81.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -28,6 +26,7 @@ require (
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a // indirect
 	google.golang.org/grpc v1.37.1 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/m-lab/gcp-config
 
-go 1.21
+go 1.18
 
 require (
+	cloud.google.com/go v0.81.0
 	github.com/go-test/deep v1.0.4
 	github.com/google/go-github/v35 v35.2.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -10,14 +11,15 @@ require (
 	github.com/stephen-soltesz/pretty v0.0.0-20181228034758-e18cda1ae6b8
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	google.golang.org/api v0.46.0
+	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a
 	gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0
 )
 
 require (
-	cloud.google.com/go v0.81.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -26,7 +28,6 @@ require (
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a // indirect
 	google.golang.org/grpc v1.37.1 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )


### PR DESCRIPTION
This PR changes the Go version back to 1.20. For more details, see [this](https://github.com/m-lab/dev-tracker/issues/771#issuecomment-1690008862) comment.

I've cleaned up the container registry versions corresponding to Go 1.21.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/76)
<!-- Reviewable:end -->
