### PR TITLE
Add option to specify interval for transfer jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20
 
 ADD . /go/src/github.com/m-lab/gcp-config
 WORKDIR /go/src/github.com/m-lab/gcp-config/
-RUN go install -v github.com/m-lab/gcp-config/cmd/stctl@v1.3.12
-RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@v1.3.12
+RUN go install -v github.com/m-lab/gcp-config/cmd/stctl@latest
+RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@latest
 ENV SINGLE_COMMAND true
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20
 
 ADD . /go/src/github.com/m-lab/gcp-config
 WORKDIR /go/src/github.com/m-lab/gcp-config/
-RUN go install -v github.com/m-lab/gcp-config/cmd/stctl@latest
-RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@latest
+RUN go install -v ./cmd/stctl
+RUN go install -v ./cmd/cbif
 ENV SINGLE_COMMAND true
 ENTRYPOINT ["/go/bin/cbif"]

--- a/cmd/stctl/main.go
+++ b/cmd/stctl/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,6 +36,7 @@ var (
 	destBucket          string
 	prefixes            flagx.StringArray
 	startTime           flagx.Time
+	interval            string
 	afterDate           flagx.DateTime
 	minAge              time.Duration
 	maxAge              time.Duration
@@ -48,6 +49,7 @@ func init() {
 	flag.StringVar(&destBucket, "gcs.target", "", "Destination bucket.")
 	flag.Var(&prefixes, "include", "Only transfer files with given prefix. Default all prefixes. Can be specified multiple times.")
 	flag.Var(&startTime, "time", "Start daily transfer at this time (HH:MM:SS)")
+	flag.StringVar(&interval, "interval", "", "Interval between the start of each scheduled transfer operation.")
 	flag.Var(&afterDate, "after", "Only list operations that ran after the given date. Default is all dates.")
 	flag.DurationVar(&minAge, "minFileAge", 0, "Minimum time since file modification")
 	flag.DurationVar(&maxAge, "maxFileAge", 0, "Maximum time since file modification")
@@ -107,6 +109,7 @@ func main() {
 		TargetBucket:        destBucket,
 		Prefixes:            prefixes,
 		StartTime:           startTime,
+		Interval:            interval,
 		AfterDate:           afterDate.Time,
 		MinFileAge:          minAge.Truncate(time.Second),
 		MaxFileAge:          maxAge.Truncate(time.Second),

--- a/daily-archive-transfers.yaml
+++ b/daily-archive-transfers.yaml
@@ -41,11 +41,6 @@ steps:
 
 # Nodes upload to the pusher-* bucket every 2 hours.
 # Configure hourly pusher to local archive transfer.
-# NOTE: the hourly setting has been set by editing the job created
-# in the web UI (because it is not supported by stctl), so this
-# declaration is not identical to what is in the corresponding GCP
-# config.
-# TODO(cristinaleon): Add hourly schedule functionality to stctl.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-oti
@@ -53,6 +48,7 @@ steps:
     'stctl', '-gcs.source=pusher-$PROJECT_ID',
              '-gcs.target=archive-$PROJECT_ID',
              '-time=00:00:00',
+             '-interval=3600s',
              '-include=autoload',
              '-deleteAfterTransfer=true',
              'sync'
@@ -70,6 +66,7 @@ steps:
              '-gcs.target=archive-measurement-lab',
              '-include=revtr',
              '-time=02:30:00',
+             '-interval=3600s',
              '-maxFileAge=27h',
              'sync'
   ]
@@ -132,11 +129,6 @@ steps:
   ]
 
 # Hourly local archive to public archive transfer for autoloaded data.
-# NOTE: the hourly setting has been set by editing the job created
-# in the web UI (because it is not supported by stctl), so this
-# declaration is not identical to what is in the corresponding GCP
-# config.
-# TODO(cristinaleon): Add hourly schedule functionality to stctl.
 - name: gcp-config-cbif
   env:
   - PROJECT_IN=measurement-lab
@@ -144,6 +136,7 @@ steps:
     'stctl', '-gcs.source=archive-mlab-oti',
              '-gcs.target=archive-measurement-lab',
              '-time=00:00:00',
+             '-interval=3600s',
              '-include=autoload',
              '-deleteAfterTransfer=true',
              'sync'

--- a/internal/stctl/command.go
+++ b/internal/stctl/command.go
@@ -48,6 +48,7 @@ type Command struct {
 	TargetBucket        string
 	Prefixes            []string
 	StartTime           flagx.Time
+	Interval            string
 	AfterDate           time.Time
 	MinFileAge          time.Duration
 	MaxFileAge          time.Duration

--- a/internal/stctl/create.go
+++ b/internal/stctl/create.go
@@ -35,6 +35,7 @@ func (c *Command) Create(ctx context.Context) (*storagetransfer.TransferJob, err
 				Minutes: int64(c.StartTime.Minute),
 				Seconds: int64(c.StartTime.Second),
 			},
+			RepeatInterval: c.Interval,
 		},
 		Status:       "ENABLED",
 		TransferSpec: &spec,

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -106,6 +106,12 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 		logx.Debug.Println("spec: times not equal", job.Schedule, c.StartTime)
 		return false
 	}
+
+	if job.Schedule.RepeatInterval != c.Interval {
+		logx.Debug.Println("spec: interval not equal", job.Schedule.RepeatInterval, c.Interval)
+		return false
+	}
+
 	cond := job.TransferSpec.ObjectConditions
 	if cond == nil {
 		if len(c.Prefixes) > 0 || c.MaxFileAge > 0 || c.MinFileAge > 0 {

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -107,6 +107,9 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 		return false
 	}
 
+	pretty.Print(job.Schedule.RepeatInterval)
+	pretty.Print(c.Interval)
+
 	if job.Schedule.RepeatInterval != c.Interval {
 		logx.Debug.Println("spec: interval not equal", job.Schedule.RepeatInterval, c.Interval)
 		return false

--- a/internal/stctl/sync.go
+++ b/internal/stctl/sync.go
@@ -107,10 +107,7 @@ func (c *Command) specMatches(job *storagetransfer.TransferJob) bool {
 		return false
 	}
 
-	pretty.Print(job.Schedule.RepeatInterval)
-	pretty.Print(c.Interval)
-
-	if job.Schedule.RepeatInterval != c.Interval {
+	if c.Interval != "" && job.Schedule.RepeatInterval != c.Interval {
 		logx.Debug.Println("spec: interval not equal", job.Schedule.RepeatInterval, c.Interval)
 		return false
 	}


### PR DESCRIPTION
This PR adds an option to specify a repeat interval for transfer jobs.

It replaces previous 1 hour intervals previously set through the Transfer Job UI and it adds 1 hour transfers for revtr data.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/78)
<!-- Reviewable:end -->
