### PR TITLE
Create Artifact Registry images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,3 +49,8 @@ images:
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1'
 - 'gcr.io/$PROJECT_ID/epoxy-images:1.1'
 - 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.1'
+- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/golang-cbif:1.20'
+- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1'
+- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.1'
+- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/siteinfo-cbif:1.1'
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,8 +49,8 @@ images:
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1'
 - 'gcr.io/$PROJECT_ID/epoxy-images:1.1'
 - 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.1'
-- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/golang-cbif:1.20'
-- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1'
-- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.1'
-- 'uscentral1-docker.pkg.dev/$PROJECT_ID/build-images/siteinfo-cbif:1.1'
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/golang-cbif:1.20'
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1'
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.1'
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/siteinfo-cbif:1.1'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,9 @@ steps:
 # Build golang-cbif container. Useful golang builds and tests.
 - name: gcr.io/cloud-builders/docker
   args: [
-    'build', '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.20',
+    'build',
+    '--tag=gcr.io/$PROJECT_ID/golang-cbif:1.20',
+    '--tag=us-central1-docker.pkg.dev/$PROJECT_ID/build-images/golang-cbif:1.20',
     '--file=Dockerfile.golang', '.'
   ]
 
@@ -22,6 +24,7 @@ steps:
   args: [
     'build',
     '--tag=gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1',
+    '--tag=us-central1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1',
     '--file=Dockerfile.jsonnet', '.'
   ]
   waitFor: ['-']
@@ -31,6 +34,7 @@ steps:
   args: [
     'build',
     '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.1',
+    '--tag=us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.1',
     '--file=Dockerfile.epoxy-images', '.'
   ]
   waitFor: ['-']
@@ -40,6 +44,7 @@ steps:
   args: [
     'build',
     '--tag=gcr.io/$PROJECT_ID/siteinfo-cbif:1.1',
+    '--tag=us-central1-docker.pkg.dev/$PROJECT_ID/build-images/siteinfo-cbif:1.1',
     '--file=Dockerfile.siteinfo', '.'
   ]
   waitFor: ['-']


### PR DESCRIPTION
Today, most all of our Cloud Build images are stored in Container Registry. Container Registry still works but is deprecated. Artifact Registry is far more flexible and configurable.

This PR creates Artifact Registry images for all the images that we currently create in Container Registry. Having both should allow us to slowly migrate to Artifact Registry.  The new "build-images" AR repository publicly readable, meaning that we will be able to use the images from mlab-oti to build things in other production projects like mlab-autojoin and measurement-lab without the need for special service accounts and permissions.

Related PR in terraform-support: https://github.com/m-lab/terraform-support/pull/71

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/80)
<!-- Reviewable:end -->
