### PR TITLE
Updates epoxy-images build image

### DIFF
--- a/Dockerfile.epoxy-images
+++ b/Dockerfile.epoxy-images
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --fix-missing
 RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
@@ -6,24 +6,8 @@ RUN apt-get install -y unzip python3-pip git vim-nox make autoconf gcc mkisofs \
     isolinux bc texinfo libncurses-dev linux-source debootstrap gcc \
     strace cpio squashfs-tools curl lsb-release gawk rsync \
     mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
-    linux-source xorriso jq
+    linux-source xorriso jq golang
 
-# Fetch recent go version.
-# NOTE: As of 2023-03-20, golang-1.20 was not an available package in ubuntu:20.04
-ENV GOLANG_VERSION 1.20.2
-ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768
-
-RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
-    && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
-    && tar -C /usr/local/ -xzf golang.tar.gz \
-    && rm golang.tar.gz
-
-ENV GOPATH /go
-RUN mkdir /go
-ENV GOROOT /usr/local/go/
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 # CGO_ENABLED=0 creates a statically linked binary.
 # The -ldflags drop another 2.5MB from the binary size.
 # -w    Omit the DWARF symbol table.
@@ -35,4 +19,9 @@ ENV PACKER_VERSION 1.8.4
 RUN curl --location --remote-name "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" \
     && unzip "packer_${PACKER_VERSION}_linux_amd64.zip" -d /usr/local/bin \
     && rm "packer_${PACKER_VERSION}_linux_amd64.zip"
+
+# Install Google Cloud SDK
+RUN curl --location --remote-name "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz" \
+    && tar -xf google-cloud-cli-linux-x86_64.tar.gz \
+    && ./google-cloud-sdk/install.sh
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,8 +33,8 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: [
     'build',
-    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.1',
-    '--tag=us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.1',
+    '--tag=gcr.io/$PROJECT_ID/epoxy-images:1.2',
+    '--tag=us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2',
     '--file=Dockerfile.epoxy-images', '.'
   ]
   waitFor: ['-']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,10 +52,10 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/golang-cbif:1.20'
 - 'gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1'
-- 'gcr.io/$PROJECT_ID/epoxy-images:1.1'
+- 'gcr.io/$PROJECT_ID/epoxy-images:1.2'
 - 'gcr.io/$PROJECT_ID/siteinfo-cbif:1.1'
 - 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/golang-cbif:1.20'
 - 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1'
-- 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.1'
+- 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2'
 - 'us-central1-docker.pkg.dev/$PROJECT_ID/build-images/siteinfo-cbif:1.1'
 


### PR DESCRIPTION
Packer builds in epoxy-images now require the presence of the Google Cloud SDK. This PR updates the epoxy-images image to include `gcloud`. Additionally, I updated the base image to the latest Ubuntu LTS release (24.04). With this change in base image, it is no longer (at least for now) necessary to jump through hoops install some newer version of Go, since the package system comes with Go 1.22.2, which is nearly the latest.

Additionally, this PR updates the the epoxy-images container image to v1.2 (from v1.1).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-config/81)
<!-- Reviewable:end -->
